### PR TITLE
Docker-ize the application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+### STAGE 1: Build ###
+
+# We label our stage as 'builder'
+FROM node:9-alpine as builder
+
+COPY package.json package-lock.json ./
+
+RUN npm set progress=false && npm config set depth 0 && npm cache clean --force
+
+## Storing node modules on a separate layer will prevent unnecessary npm installs at each build
+RUN npm i && mkdir /ng-app && cp -R ./node_modules ./ng-app
+
+WORKDIR /ng-app
+
+COPY . .
+
+## Build the angular app in production mode and store the artifacts in dist folder
+RUN $(npm bin)/ng build --prod
+
+
+### STAGE 2: Setup ###
+
+FROM nginx:1.13.3-alpine
+
+## Copy our default nginx config
+COPY nginx/default.conf /etc/nginx/conf.d/
+
+## Remove default nginx website
+RUN rm -rf /usr/share/nginx/html/*
+
+## From 'builder' stage copy over the artifacts in dist folder to default nginx public folder
+COPY --from=builder /ng-app/dist /usr/share/nginx/html
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,19 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+## Running the application in Docker
+
+Build the container:
+
+```shell
+$ docker build -t br4 .
+```
+
+Then run the container:
+
+```shell
+$ docker run --name br4 -d -p 8080:80 br4
+```
+
+Navigate to http://localhost:8080 to view the application.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,27 @@
+server {
+
+  listen 80;
+
+  sendfile on;
+
+  default_type application/octet-stream;
+
+
+  gzip on;
+  gzip_http_version 1.1;
+  gzip_disable      "MSIE [1-6]\.";
+  gzip_min_length   256;
+  gzip_vary         on;
+  gzip_proxied      expired no-cache no-store private auth;
+  gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_comp_level   9;
+
+
+  root /usr/share/nginx/html;
+
+
+  location / {
+    try_files $uri $uri/ /index.html =404;
+  }
+
+}


### PR DESCRIPTION
If the NGINX stuff is unnecessary just let me know and I'll take that out.

Ideally we'd push this to the official Docker Registry so users can just `docker run beyond-rule-4` but this is the first step towards that.