### PR TITLE
feat(forecast.expenseImpact): new expense impact table component

### DIFF
--- a/src/app/forecasting/input/ynab/ynab.component.ts
+++ b/src/app/forecasting/input/ynab/ynab.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormArray, FormControl, FormBuilder, Validators } from '@angular/forms';
-import { Router, ActivatedRoute} from '@angular/router';
-import { NgbPanelChangeEvent} from '@ng-bootstrap/ng-bootstrap';
+import { Router, ActivatedRoute } from '@angular/router';
+import { NgbPanelChangeEvent } from '@ng-bootstrap/ng-bootstrap';
 import { timer } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 import * as ynab from 'ynab';
@@ -102,9 +102,9 @@ export class YnabComponent implements OnInit {
       categoryGroups: this.formBuilder.array([]),
       accounts: this.formBuilder.array([]),
       safeWithdrawalRatePercentage: [this.safeWithdrawalRatePercentage,
-        [Validators.required, Validators.max(99.99), Validators.max(0.01) ]],
+      [Validators.required, Validators.max(99.99), Validators.max(0.01)]],
       expectedAnnualGrowthRate: [this.expectedAnnualGrowthRate,
-        [Validators.required, Validators.max(99.99), Validators.max(0.01) ]],
+      [Validators.required, Validators.max(99.99), Validators.max(0.01)]],
     });
   }
 
@@ -206,7 +206,7 @@ export class YnabComponent implements OnInit {
     }
 
     if (this.selectedMonthA.month !== this.budgetForm.value.selectedMonthA ||
-        this.selectedMonthB.month !== this.budgetForm.value.selectedMonthB) {
+      this.selectedMonthB.month !== this.budgetForm.value.selectedMonthB) {
       this.selectMonths(this.budgetForm.value.selectedMonthA, this.budgetForm.value.selectedMonthB);
       return;
     }
@@ -237,6 +237,7 @@ export class YnabComponent implements OnInit {
     result.leanAnnualExpenses = this.expenses.leanFi.annual;
     result.netWorth = this.netWorth;
     result.monthlyContribution = this.budgetForm.value.monthlyContribution;
+    result.budgetCategoryGroups = this.budgetForm.value.categoryGroups;
 
     const safeWithdrawalRatePercentage = Number.parseFloat(this.budgetForm.value.safeWithdrawalRatePercentage);
     if (!Number.isNaN(safeWithdrawalRatePercentage)) {
@@ -360,15 +361,15 @@ export class YnabComponent implements OnInit {
       computedLeanFiBudget,
       contributionBudget,
       info: categoryBudgetInfo
-    }, );
+    });
   }
 
   private mapAccounts(accounts: ynab.Account[]) {
     const mapped = accounts.filter(a => !(a.closed || a.deleted))
-    .map(a => this.formBuilder.group(Object.assign({}, a, {
-      balance: this.getAccountBalance(a),
-      ynabBalance: ynab.utils.convertMilliUnitsToCurrencyAmount(a.balance)
-    })));
+      .map(a => this.formBuilder.group(Object.assign({}, a, {
+        balance: this.getAccountBalance(a),
+        ynabBalance: ynab.utils.convertMilliUnitsToCurrencyAmount(a.balance)
+      })));
     return mapped;
   }
 

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -8,6 +8,7 @@ export class CalculateInput {
   expectedAnnualGrowthRate = 0;
   monthlyContribution = 0;
   leanFiPercentage = 0;
+  budgetCategoryGroups = [];
 
   public constructor(init?: Partial<CalculateInput>) {
     Object.assign(this, {
@@ -27,4 +28,17 @@ export class CalculateInput {
     this.leanFiPercentage = round(this.leanFiPercentage);
     this.leanAnnualExpenses = round(this.leanAnnualExpenses);
   }
+
+  get fiNumber() {
+    return 1 / this.annualSafeWithdrawalRate * this.annualExpenses;
+  }
+
+  get leanFiNumber() {
+    let leanFiNumber = this.fiNumber * this.leanFiPercentage;
+    if (this.leanAnnualExpenses) {
+      leanFiNumber = 1 / this.annualSafeWithdrawalRate * this.leanAnnualExpenses;
+    }
+    return leanFiNumber;
+  }
+
 }

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -29,16 +29,19 @@ export class CalculateInput {
     this.leanAnnualExpenses = round(this.leanAnnualExpenses);
   }
 
+  get safeWidthdrawlTimes() {
+    return 1 / this.annualSafeWithdrawalRate;
+  }
+
   get fiNumber() {
-    return 1 / this.annualSafeWithdrawalRate * this.annualExpenses;
+    return this.safeWidthdrawlTimes * this.annualExpenses;
   }
 
   get leanFiNumber() {
     let leanFiNumber = this.fiNumber * this.leanFiPercentage;
     if (this.leanAnnualExpenses) {
-      leanFiNumber = 1 / this.annualSafeWithdrawalRate * this.leanAnnualExpenses;
+      leanFiNumber = this.safeWidthdrawlTimes * this.leanAnnualExpenses;
     }
     return leanFiNumber;
   }
-
 }

--- a/src/app/forecasting/models/forecast.model.ts
+++ b/src/app/forecasting/models/forecast.model.ts
@@ -44,8 +44,7 @@ export class Forecast {
   }
 
   private computeForecast(calculateInput: CalculateInput) {
-    const fiNumber = 1 / calculateInput.annualSafeWithdrawalRate * calculateInput.annualExpenses;
-    const stopForecastingAmount = fiNumber * 1.6; // default to a bit more than Fat FI.
+    const stopForecastingAmount = calculateInput.fiNumber * 1.6; // default to a bit more than Fat FI.
 
     const annualExpenses = calculateInput.annualExpenses;
     const monthlyAverageGrowth = 1 + calculateInput.expectedAnnualGrowthRate / 12;

--- a/src/app/forecasting/models/forecast.model.ts
+++ b/src/app/forecasting/models/forecast.model.ts
@@ -113,6 +113,6 @@ export class MonthlyForecast {
   }
 
   public toDateString() {
-    return this.date.toLocaleString('en-us', {month: 'long', year: 'numeric'});
+    return this.date.toLocaleString('en-us', { month: 'long', year: 'numeric' });
   }
 }

--- a/src/app/forecasting/output/fi-text/fi-text.component.ts
+++ b/src/app/forecasting/output/fi-text/fi-text.component.ts
@@ -35,16 +35,15 @@ export class FiTextComponent implements OnInit, OnChanges {
   }
 
   calculate() {
-    const safeWithdrawalTimes = 1 / this.calculateInput.annualSafeWithdrawalRate;
-    this.safeWithdrawalTimes = round(safeWithdrawalTimes);
+    this.safeWithdrawalTimes = round(this.calculateInput.safeWidthdrawlTimes);
     this.safeWithdrawalRate = round(this.calculateInput.annualSafeWithdrawalRate * 100);
 
     this.expectedAnnualGrowthRate = round(this.calculateInput.expectedAnnualGrowthRate * 100);
 
-    const fiNumber = Math.max(0, round(safeWithdrawalTimes * this.calculateInput.annualExpenses));
+    const fiNumber = Math.max(0, round(this.calculateInput.fiNumber));
     this.fiNumber = fiNumber;
 
-    const leanFiNumber = Math.max(0, round(this.safeWithdrawalTimes * this.calculateInput.leanAnnualExpenses));
+    const leanFiNumber = Math.max(0, round(this.calculateInput.leanFiNumber));
     this.leanFiNumber = leanFiNumber;
 
     if (!this.forecast) {

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -1,20 +1,19 @@
 <h1>Expense Impact on FI Date</h1>
-<p>Spending in each category increases the total time to FI. Reducing or eliminating spending in a category not only
-    decreases the total nest egg required, but this spending can be diverted into savings instead.</p>
+
 <div class="table-responsive">
     <table class="table table-striped">
         <thead>
             <tr>
                 <th>Category</th>
                 <th>FI Budget</th>
-                <th>Impact on FI Date<br><small>Assumes spending diverted from contributions</small></th>
+                <th>Impact on FI Date</th>
             </tr>
         </thead>
         <tbody>
             <tr *ngFor="let c of spendingCategoriesWithImpact">
                 <td>{{ c.category.name }}</td>
-                <td>{{ c.category.fiBudget | number }}</td>
-                <td>{{ c.impactDate }}</td>
+                <td>{{ c.category.fiBudget | currency:calculateInput.currencyIsoCode }}</td>
+                <td><i class="fas fa-plus-circle"></i> {{ c.impactDate }}</td>
             </tr>
         </tbody>
     </table>

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -13,7 +13,15 @@
             <tr *ngFor="let c of spendingCategoriesWithImpact">
                 <td>{{ c.category.name }}</td>
                 <td>{{ c.category.fiBudget | currency:calculateInput.currencyIsoCode }}</td>
-                <td><i class="fas fa-plus-circle"></i> {{ c.impactDate }}</td>
+                <td>
+                    <span [ngClass]="{'d-none': c.isFi === true}">
+                        <i class="fas fa-plus-circle"></i>
+                    </span>
+                    <span [ngClass]="{'d-none': c.isFi !== true}">
+                        <i class="fas fa-check-circle"></i>
+                    </span>
+                    {{ c.impactDate }}
+                </td>
             </tr>
         </tbody>
     </table>

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -1,17 +1,21 @@
 <h1>Expense Impact on FI Date</h1>
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>Category</th>
-            <th>FI Budget</th>
-            <th>Impact on FI Date</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr *ngFor="let c of spendingCategoriesWithImpact">
-            <td>{{ c.category.name }}</td>
-            <td>{{ c.category.fiBudget | currency }}</td>
-            <td>{{ c.impactDate }}</td>
-        </tr>
-    </tbody>
-</table>
+<p>Spending in each category increases the total time to FI. Reducing or eliminating spending in a category not only
+    decreases the total nest egg required, but this spending can be diverted into savings instead.</p>
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Category</th>
+                <th>FI Budget</th>
+                <th>Impact on FI Date<br><small>Assumes spending diverted from contributions</small></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr *ngFor="let c of spendingCategoriesWithImpact">
+                <td>{{ c.category.name }}</td>
+                <td>{{ c.category.fiBudget | number }}</td>
+                <td>{{ c.impactDate }}</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -1,5 +1,8 @@
 <h1>Expense Impact on FI Date</h1>
-
+<p>Each component of your spending adds time to your FI Date. Eliminate spending in a category below and move that
+    spending to savings contributions, and you can reduce your FI Date by the amount under <strong>Impact on FI
+        Date</strong>.
+</p>
 <div class="table-responsive">
     <table class="table table-striped">
         <thead>

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -1,0 +1,17 @@
+<h1>Expense Impact on FI Date</h1>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Spending Category</th>
+            <th>FI Budget</th>
+            <th>Impact on FI Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr *ngFor="let c of spendingCategoriesWithImpact">
+            <td>{{ c.category.name }}</td>
+            <td>{{ c.category.fiBudget | currency }}</td>
+            <td>{{ c.impactDate }}</td>
+        </tr>
+    </tbody>
+</table>

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -2,7 +2,7 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th>Spending Category</th>
+            <th>Category</th>
             <th>FI Budget</th>
             <th>Impact on FI Date</th>
         </tr>

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -72,6 +72,10 @@ export class ImpactComponent implements OnInit, OnChanges {
     }
 
     private getImpactDateText(currentDate: Date, newDate: Date): string {
+        if (newDate > currentDate) {
+            return "<1 day";
+        }
+
         var diffDate = new Date(currentDate.getTime() - newDate.getTime())
 
         var years = "";

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -39,6 +39,18 @@ export class ImpactComponent implements OnInit, OnChanges {
         });
 
         this.spendingCategoriesWithImpact = categoriesWithSpending.map((category) => {
+            const isFi = !this.forecast.getDistanceFromFirstMonthText(currentFiForecast.date);
+
+            if (isFi) {
+                let impactDate = 'Achieved FI!';
+
+                return {
+                    category,
+                    impactDate,
+                    isFi
+                };
+            }
+
             const modifiedCalcInput = this.getModifiedCalculateInput(category.fiBudget);
             const modifiedForecast = new Forecast(modifiedCalcInput);
             const modifiedFiForecast = this.getFiForecast(modifiedForecast, modifiedCalcInput.fiNumber);
@@ -47,7 +59,8 @@ export class ImpactComponent implements OnInit, OnChanges {
 
             return {
                 category,
-                impactDate
+                impactDate,
+                isFi
             };
         });
     }

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnInit, Input, OnChanges, SimpleChanges, } from '@angular/core';
+import { Forecast } from '../../models/forecast.model';
+import { CalculateInput } from '../../models/calculate-input.model';
+
+@Component({
+    selector: 'app-expense-impact',
+    templateUrl: 'impact.component.html'
+})
+
+export class ImpactComponent implements OnInit, OnChanges {
+
+    @Input() calculateInput: CalculateInput;
+    @Input() forecast: Forecast;
+
+    spendingCategoriesWithImpact;
+
+    ngOnInit() {
+        this.calculateData();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        this.calculateData();
+    }
+
+    calculateData() {
+        if (!this.calculateInput.budgetCategoryGroups) {
+            return;
+        }
+
+        const currentFiForecast = this.getFiForecast(this.forecast, this.calculateInput.fiNumber);
+
+        const flattenCategories = [].concat(...this.calculateInput.budgetCategoryGroups.map((group) => {
+            return group.categories;
+        }));
+        const categoriesWithSpending = flattenCategories.filter((category) => {
+            return category.fiBudget > 0;
+        }).sort((a, b) => {
+            return b.fiBudget - a.fiBudget;
+        });
+
+        this.spendingCategoriesWithImpact = categoriesWithSpending.map((category) => {
+
+            const modifiedCalcInput = this.getModifiedCalculateInput(category.fiBudget);
+
+            const modifiedForecast = new Forecast(modifiedCalcInput);
+
+            const modifiedFiForecast = this.getFiForecast(modifiedForecast, modifiedCalcInput.fiNumber);
+
+            const impactDate = this.getImpactDateText(currentFiForecast.date, modifiedFiForecast.date);
+
+            return {
+                category,
+                impactDate
+            };
+        });
+    }
+
+    private getModifiedCalculateInput(spendingReductionPerMonth: number): CalculateInput {
+        const yearlySpendingReduction = spendingReductionPerMonth * 12;
+
+        const calcInput = new CalculateInput();
+        calcInput.annualExpenses = this.calculateInput.annualExpenses - yearlySpendingReduction;
+        calcInput.annualSafeWithdrawalRate = this.calculateInput.annualSafeWithdrawalRate;
+        calcInput.expectedAnnualGrowthRate = this.calculateInput.expectedAnnualGrowthRate;
+        calcInput.netWorth = this.calculateInput.netWorth;
+        calcInput.monthlyContribution = this.calculateInput.monthlyContribution + spendingReductionPerMonth;
+        return calcInput;
+    }
+
+    private getFiForecast(forecast: Forecast, fiNumber: number) {
+        return forecast.monthlyForecasts.find(f => f.netWorth >= fiNumber);
+    }
+
+    private getImpactDateText(currentDate: Date, newDate: Date): string {
+        var diffDate = new Date(currentDate.getTime() - newDate.getTime())
+
+        var years = "";
+        if (diffDate.getUTCFullYear() - 1970 > 0) {
+            years = diffDate.getUTCFullYear() - 1970 + " years ";
+        }
+
+        var months = "";
+        if (diffDate.getUTCMonth() > 0) {
+            months = diffDate.getUTCMonth() + " months ";
+        }
+        var days = "";
+        if (!years && !months) {
+            days = diffDate.getUTCDay() + " days ";
+        }
+
+        return years + months + days;
+    }
+}

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -70,18 +70,20 @@ export class ImpactComponent implements OnInit, OnChanges {
             return "<1 day";
         }
 
-        var diffDate = new Date(currentDate.getTime() - newDate.getTime())
+        let diffDate = new Date(currentDate.getTime() - newDate.getTime())
 
-        var years = "";
+        let years = "";
+        let months = "";
+        let days = "";
+
         if (diffDate.getUTCFullYear() - 1970 > 0) {
             years = diffDate.getUTCFullYear() - 1970 + " years ";
         }
 
-        var months = "";
         if (diffDate.getUTCMonth() > 0) {
             months = diffDate.getUTCMonth() + " months ";
         }
-        var days = "";
+
         if (!years && !months) {
             days = diffDate.getUTCDay() + " days ";
         }

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -42,7 +42,6 @@ export class ImpactComponent implements OnInit, OnChanges {
             const modifiedCalcInput = this.getModifiedCalculateInput(category.fiBudget);
             const modifiedForecast = new Forecast(modifiedCalcInput);
             const modifiedFiForecast = this.getFiForecast(modifiedForecast, modifiedCalcInput.fiNumber);
-
             const impactDate = this.getImpactDateText(currentFiForecast.date, modifiedFiForecast.date);
 
             return {
@@ -52,13 +51,13 @@ export class ImpactComponent implements OnInit, OnChanges {
         });
     }
 
-    private getModifiedCalculateInput(spendingReductionPerMonth: number): CalculateInput {
+    private getModifiedCalculateInput(fiSpendingReductionPerMonth: number): CalculateInput {
         const calcInput = new CalculateInput();
-        calcInput.annualExpenses = this.calculateInput.annualExpenses - spendingReductionPerMonth * 12;
+        calcInput.annualExpenses = this.calculateInput.annualExpenses - fiSpendingReductionPerMonth * 12;
         calcInput.annualSafeWithdrawalRate = this.calculateInput.annualSafeWithdrawalRate;
         calcInput.expectedAnnualGrowthRate = this.calculateInput.expectedAnnualGrowthRate;
         calcInput.netWorth = this.calculateInput.netWorth;
-        calcInput.monthlyContribution = this.calculateInput.monthlyContribution + spendingReductionPerMonth;
+        calcInput.monthlyContribution = this.calculateInput.monthlyContribution + fiSpendingReductionPerMonth;
         return calcInput;
     }
 

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -29,21 +29,18 @@ export class ImpactComponent implements OnInit, OnChanges {
 
         const currentFiForecast = this.getFiForecast(this.forecast, this.calculateInput.fiNumber);
 
-        const flattenCategories = [].concat(...this.calculateInput.budgetCategoryGroups.map((group) => {
+        const categories = [].concat(...this.calculateInput.budgetCategoryGroups.map((group) => {
             return group.categories;
         }));
-        const categoriesWithSpending = flattenCategories.filter((category) => {
+        const categoriesWithSpending = categories.filter((category) => {
             return category.fiBudget > 0;
         }).sort((a, b) => {
             return b.fiBudget - a.fiBudget;
         });
 
         this.spendingCategoriesWithImpact = categoriesWithSpending.map((category) => {
-
             const modifiedCalcInput = this.getModifiedCalculateInput(category.fiBudget);
-
             const modifiedForecast = new Forecast(modifiedCalcInput);
-
             const modifiedFiForecast = this.getFiForecast(modifiedForecast, modifiedCalcInput.fiNumber);
 
             const impactDate = this.getImpactDateText(currentFiForecast.date, modifiedFiForecast.date);
@@ -56,10 +53,8 @@ export class ImpactComponent implements OnInit, OnChanges {
     }
 
     private getModifiedCalculateInput(spendingReductionPerMonth: number): CalculateInput {
-        const yearlySpendingReduction = spendingReductionPerMonth * 12;
-
         const calcInput = new CalculateInput();
-        calcInput.annualExpenses = this.calculateInput.annualExpenses - yearlySpendingReduction;
+        calcInput.annualExpenses = this.calculateInput.annualExpenses - spendingReductionPerMonth * 12;
         calcInput.annualSafeWithdrawalRate = this.calculateInput.annualSafeWithdrawalRate;
         calcInput.expectedAnnualGrowthRate = this.calculateInput.expectedAnnualGrowthRate;
         calcInput.netWorth = this.calculateInput.netWorth;

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -42,6 +42,7 @@ export class ImpactComponent implements OnInit, OnChanges {
             const modifiedCalcInput = this.getModifiedCalculateInput(category.fiBudget);
             const modifiedForecast = new Forecast(modifiedCalcInput);
             const modifiedFiForecast = this.getFiForecast(modifiedForecast, modifiedCalcInput.fiNumber);
+
             const impactDate = this.getImpactDateText(currentFiForecast.date, modifiedFiForecast.date);
 
             return {
@@ -66,28 +67,29 @@ export class ImpactComponent implements OnInit, OnChanges {
     }
 
     private getImpactDateText(currentDate: Date, newDate: Date): string {
-        if (newDate > currentDate) {
-            return "<1 day";
+        let monthDifference =
+            ((currentDate.getFullYear() - newDate.getFullYear()) * 12)
+            + (currentDate.getMonth() - newDate.getMonth());
+
+        if (monthDifference === 0) {
+            return "<1 month";
         }
 
-        let diffDate = new Date(currentDate.getTime() - newDate.getTime())
+        monthDifference = Math.abs(monthDifference);
 
-        let years = "";
-        let months = "";
-        let days = "";
+        const months = monthDifference % 12;
+        const years = (monthDifference - months) / 12;
+        const difference = this.getTimeString(years, 'year') + this.getTimeString(months, 'month');
+        return difference;
+    }
 
-        if (diffDate.getUTCFullYear() - 1970 > 0) {
-            years = diffDate.getUTCFullYear() - 1970 + " years ";
+    private getTimeString(timeDifference: number, unit: string): string {
+        if (timeDifference === 0) {
+            return '';
         }
-
-        if (diffDate.getUTCMonth() > 0) {
-            months = diffDate.getUTCMonth() + " months ";
+        if (timeDifference === 1) {
+            return `1 ${unit} `;
         }
-
-        if (!years && !months) {
-            days = diffDate.getUTCDay() + " days ";
-        }
-
-        return years + months + days;
+        return `${timeDifference} ${unit}s `;
     }
 }

--- a/src/app/forecasting/output/impact/impact.module.ts
+++ b/src/app/forecasting/output/impact/impact.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { ImpactComponent } from './impact.component';
+import { SharedModule } from '../../../shared.module';
+
+@NgModule({
+    imports: [SharedModule],
+    exports: [ImpactComponent],
+    declarations: [ImpactComponent],
+    providers: []
+})
+
+export class ImpactModule { }

--- a/src/app/forecasting/output/milestones/milestones.component.ts
+++ b/src/app/forecasting/output/milestones/milestones.component.ts
@@ -28,20 +28,15 @@ export class MilestonesComponent implements OnInit, OnChanges {
   }
 
   calculate() {
-    const fiNumber = 1 / this.calculateInput.annualSafeWithdrawalRate * this.calculateInput.annualExpenses;
-    let leanFiNumber = fiNumber * this.calculateInput.leanFiPercentage;
-    if (this.calculateInput.leanAnnualExpenses) {
-      leanFiNumber = 1 / this.calculateInput.annualSafeWithdrawalRate * this.calculateInput.leanAnnualExpenses;
-    }
     const eclipseForecast = this.forecast.monthlyForecasts.find(m => {
       return m.totalContributions <= m.totalReturns;
     });
     if (!eclipseForecast) {
-      this.milestones = new Milestones(fiNumber, leanFiNumber, 0);
+      this.milestones = new Milestones(this.calculateInput.fiNumber, this.calculateInput.leanFiNumber, 0);
       return;
     }
 
     const eclipseMarker = Math.min(eclipseForecast.totalContributions, eclipseForecast.totalReturns);
-    this.milestones = new Milestones(fiNumber, leanFiNumber, eclipseMarker * 2);
+    this.milestones = new Milestones(this.calculateInput.fiNumber, this.calculateInput.leanFiNumber, eclipseMarker * 2);
   }
 }

--- a/src/app/forecasting/output/milestones/text/text.component.ts
+++ b/src/app/forecasting/output/milestones/text/text.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, OnChanges, SimpleChanges,  } from '@angular/core';
+import { Component, OnInit, Input, OnChanges, SimpleChanges, } from '@angular/core';
 
 import { CalculateInput } from '../../../models/calculate-input.model';
 import { Forecast, MonthlyForecast } from '../../../models/forecast.model';

--- a/src/app/forecasting/output/output.component.html
+++ b/src/app/forecasting/output/output.component.html
@@ -8,7 +8,7 @@
       <app-milestones class="col" [calculateInput]="calculateInput" [forecast]="forecast">
       </app-milestones>
     </div>
-    <div class="row">
+    <div class="row mt-4">
       <app-expense-impact class="col" [calculateInput]="calculateInput" [forecast]="forecast">
       </app-expense-impact>
     </div>

--- a/src/app/forecasting/output/output.component.html
+++ b/src/app/forecasting/output/output.component.html
@@ -1,18 +1,16 @@
 <div class="row" *ngIf="calculateInput">
   <div class="col">
     <div class="row">
-        <app-fi-text
-          class="col"
-          [calculateInput]="calculateInput"
-          [forecast]="forecast">
-        </app-fi-text>
+      <app-fi-text class="col" [calculateInput]="calculateInput" [forecast]="forecast">
+      </app-fi-text>
     </div>
     <div class="row">
-      <app-milestones
-        class="col"
-        [calculateInput]="calculateInput"
-        [forecast]="forecast">
+      <app-milestones class="col" [calculateInput]="calculateInput" [forecast]="forecast">
       </app-milestones>
+    </div>
+    <div class="row">
+      <app-expense-impact class="col" [calculateInput]="calculateInput" [forecast]="forecast">
+      </app-expense-impact>
     </div>
   </div>
 </div>

--- a/src/app/forecasting/output/output.module.ts
+++ b/src/app/forecasting/output/output.module.ts
@@ -4,12 +4,14 @@ import { SharedModule } from '../../shared.module';
 import { ForecastingOutputComponent } from './output.component';
 import { MilestonesModule } from './milestones/milestones.module';
 import { FiTextModule } from './fi-text/fi-text.module';
+import { ImpactModule } from './impact/impact.module';
 
 @NgModule({
   imports: [
     SharedModule,
     MilestonesModule,
     FiTextModule,
+    ImpactModule
   ],
   exports: [ForecastingOutputComponent],
   declarations: [ForecastingOutputComponent],


### PR DESCRIPTION
This feature is based on something I've been doing by hand up until this point: I find it useful to think of each spending category in terms of how much _impact_ it has on my FI date.

This new table will show each category with a FI budget >$0, and show how much of an impact that spending has on arriving at FI. The code also factors in opportunity cost by adding the budgeted amount into contributions when calculating said impact.