### PR TITLE
Tweaks to container init: allowing image configuration w/o code changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,5 @@ RUN rm -rf /usr/share/nginx/html/*
 ## From 'builder' stage copy over the artifacts in dist folder to default nginx public folder
 COPY --from=builder /ng-app/dist /usr/share/nginx/html
 
-CMD ["nginx", "-g", "daemon off;"]
+## Replace environment variables + start app
+CMD ["/bin/sh",  "-c",  "envsubst < /usr/share/nginx/html/assets/env.template.js > /usr/share/nginx/html/assets/env.js && exec nginx -g 'daemon off;'"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ To get more help on the Angular CLI use `ng help` or go check out the [Angular C
 
 ## Running the application in Docker
 
+In order to successfully authenticate with YNAB, you will need a [YNAB API OAuth Application Token](https://api.youneedabudget.com/). Your Client ID and Redirect URI(s) will used when running your container. 
+
 Build the container:
 
 ```shell
@@ -45,7 +47,7 @@ $ docker build -t br4 .
 Then run the container:
 
 ```shell
-$ docker run --name br4 -d -p 8080:80 br4
+$ docker run --name br4 -d -p 8080:80 --env APP_URL="http://localhost:8080" --env CLIENT_ID="<CLIENT_ID_FROM_YNAB>" br4
 ```
 
-Navigate to http://localhost:8080 to view the application.
+Navigate to http://localhost:8080 to view the application. Note: This example uses port 8080, which will be required in the Redirect URI when registering your OAuth application. You are free to use other ports.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,27 @@ To get more help on the Angular CLI use `ng help` or go check out the [Angular C
 
 ## Running the application in Docker
 
-In order to successfully authenticate with YNAB, you will need a [YNAB API OAuth Application Token](https://api.youneedabudget.com/). Your Client ID and Redirect URI(s) will used when running your container. 
+### Quick Start (uses default dev localhost token)
+
+Build the container:
+
+```shell
+$ docker build -t br4 .
+```
+
+Then run the container:
+
+```shell
+$ docker run --name br4 -d -p 4200:80 br4
+```
+
+Navigate to http://localhost:4200 to view the application.
+
+### Using custom tokens
+
+You can utilize your own [YNAB API OAuth Application Token](https://api.youneedabudget.com/) by injecting environment variables.
+
+Your Client ID and Redirect URI(s) will be used when running your container. 
 
 Build the container:
 

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -1,0 +1,7 @@
+(function(window) {
+  window["env"] = window["env"] || {};
+
+  // Environment variables
+  window["env"]["clientId"] = window["env"]["clientId"] || "e9755d570a9a471868f54697e4d989fc3d5785b067c7e4b556b85ed6be3606c0";
+  window["env"]["appUrl"] = window["env"]["appUrl"] || "https://beyondrule4.jmmorrissey.com";
+})(this);

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -1,7 +1,5 @@
 (function(window) {
-  window["env"] = window["env"] || {};
+  window['env'] = window['env'] || {};
 
-  // Environment variables
-  window["env"]["clientId"] = window["env"]["clientId"] || "e9755d570a9a471868f54697e4d989fc3d5785b067c7e4b556b85ed6be3606c0";
-  window["env"]["appUrl"] = window["env"]["appUrl"] || "https://beyondrule4.jmmorrissey.com";
+  // this can get replaced via Docker to supply runtime variables. See the README
 })(this);

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -1,0 +1,7 @@
+(function(window) {
+  window["env"] = window["env"] || {};
+
+  // Environment variables
+  window["env"]["clientId"] = window["env"]["clientId"] || "${CLIENT_ID}";
+  window["env"]["appUrl"] = window["env"]["appUrl"] || "${APP_URL}";
+})(this);

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -1,7 +1,7 @@
 (function(window) {
-  window["env"] = window["env"] || {};
+  window['env'] = window['env'] || {};
 
   // Environment variables
-  window["env"]["clientId"] = window["env"]["clientId"] || "${CLIENT_ID}";
-  window["env"]["appUrl"] = window["env"]["appUrl"] || "${APP_URL}";
+  window['env']['clientId'] = '${CLIENT_ID}' || '7aec43a65f3a487eaf02d9781954537dde8c8f6929d8573935eb359742f9fc6d';
+  window['env']['appUrl'] = '${APP_URL}' || 'http://localhost:4200';
 })(this);

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  clientId: 'e9755d570a9a471868f54697e4d989fc3d5785b067c7e4b556b85ed6be3606c0',
-  redirectUri: 'https://beyondrule4.jmmorrissey.com/connect'
+  clientId: (window['env']['clientId'] || 'e9755d570a9a471868f54697e4d989fc3d5785b067c7e4b556b85ed6be3606c0'),
+  redirectUri: (window['env']['appUrl'] || 'https://beyondrule4.jmmorrissey.com') + '/connect'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,6 +5,6 @@
 
 export const environment = {
   production: false,
-  clientId: '7aec43a65f3a487eaf02d9781954537dde8c8f6929d8573935eb359742f9fc6d',
-  redirectUri: 'http://localhost:4200/connect'
+  clientId: (window['env']['clientId'] || '7aec43a65f3a487eaf02d9781954537dde8c8f6929d8573935eb359742f9fc6d'),
+  redirectUri: (window['env']['appUrl'] || 'http://localhost:4200') + '/connect' 
 };

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="assets/favicon.png">
 
+  <!-- Load environment variables -->
+  <script src="assets/env.js"></script>
+  
   <script>
     if (window.matchMedia('(prefers-color-scheme: dark)').media === 'not all') {
       document.documentElement.style.display = 'none';


### PR DESCRIPTION
Hey - sorry for not socializing ahead, I figure this is a change I needed and won't be hurt if you don't want/need the code. 

**Why**
I went to locally host BR4 on my own machine (80% curiosity, 20% privacy) and found that strictly as is, the Client Ids and Redirect URLs are baked into the configs. Since I wanted this running as a container & more flexible, I needed to break from the current method of choosing Client Id + Redirect. 

**How**
Changes implement [this](https://pumpingco.de/blog/environment-variables-angular-docker/) online guide for how to parameterize angular apps that are built into a container. 

**Example** 
- Build docker image as normal
- `docker run --name br4 -d -p <port>:80 --env APP_URL="<url>" --env CLIENT_ID="<clientid>" br4:latest`
- Image will run on your chosen port, with your client id, and authorization requests will redirect to your url.

**Notes**
- Existing flow is respected, building the repo exactly as is will be in "prod" mode with your URL/clientId. 
- Dropping "--prod" from the angular build command in the DOCKERFILE will still build to your local URL + clientId.

**Caveat Emptor**
- I don't know squat about any of the technologies used here. Changes should be honestly reviewed before used. They have been tested to my satisfaction, but that should mean zilch since I'm an internet rando. Happy to fix any issues you may find, though.