### PR TITLE
QOL: Adding "Quick Choose" options for budget month selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.sublime-workspace
 
 # IDE - VSCode
+.vs/*
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -58,8 +58,21 @@
                 </select>
               </div>
             </div>
-
           </div>
+      
+      <div class="row">
+            <label for="selectedBudget" class="col-sm-12 col-md-5 col-form-label">Quick Choose</label>
+            <div class="col">
+              <div class="btn-group btn-group-sm d-flex" role="group" aria-label="Basic example">
+                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('all')">All</button>
+                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('yr')">Last Yr</button>
+                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('12')">Last 12 Mo</button>
+                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('ytd')">YTD</button>
+                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('curr')">Current Month</button>
+              </div>
+            </div>
+          </div>
+      
           <div class="row">
             <div class="col">
               <small>The month range to use for average contributions and expenses

--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -4,7 +4,6 @@
 </div>
 
 <form [formGroup]="budgetForm">
-
   <ngb-accordion [closeOthers]="false" (panelChange)="beforePanelChange($event)">
     <ngb-panel id="pSettings">
       <ng-template ngbPanelTitle>
@@ -59,20 +58,23 @@
               </div>
             </div>
           </div>
-      
-      <div class="row">
-            <label for="selectedBudget" class="col-sm-12 col-md-5 col-form-label">Quick Choose</label>
+     
+          <div class="row">
+            <label for="selectedBudget" class="col-sm-12 col-md-5 col-form-label"></label>
             <div class="col">
-              <div class="btn-group btn-group-sm d-flex" role="group" aria-label="Basic example">
-                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('all')">All</button>
-                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('yr')">Last Yr</button>
-                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('12')">Last 12 Mo</button>
-                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('ytd')">YTD</button>
-                <button type="button" class="btn btn-secondary w-100" (click)="quickChooseMonths('curr')">Current Month</button>
+              <div ngbDropdown class="input-group d-inline-block">
+                <button class="btn btn-outline-secondary btn-sm w-100" id="dropdownBasic1" ngbDropdownToggle>Quick Choose</button>
+                <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+                  <button ngbDropdownItem (click)="quickChooseMonths('all')">All</button>
+                  <button ngbDropdownItem (click)="quickChooseMonths('yr')">Last Year</button>
+                  <button ngbDropdownItem (click)="quickChooseMonths('12')">Last 12 Months</button>
+                  <button ngbDropdownItem (click)="quickChooseMonths('ytd')">YTD</button>
+                  <button ngbDropdownItem (click)="quickChooseMonths('curr')">Current Month</button>
+                </div>
               </div>
             </div>
           </div>
-      
+
           <div class="row">
             <div class="col">
               <small>The month range to use for average contributions and expenses
@@ -87,7 +89,7 @@
             <div class="col">
               <div class="input-group">
                 <input type="number" class="form-control" id="safeWithdrawalRatePercentage"
-                  formControlName="safeWithdrawalRatePercentage" step="0.01">
+                  formControlName="safeWithdrawalRatePercentage" step="0.01" />
                 <div class="input-group-append">
                   <div class="input-group-text">%</div>
                 </div>

--- a/src/app/forecasting/input/ynab/ynab.component.ts
+++ b/src/app/forecasting/input/ynab/ynab.component.ts
@@ -187,8 +187,7 @@ export class YnabComponent implements OnInit {
     const currentMonth = await this.ynabService.getMonth(budgetId, 'current');
     let currentMonthIdx = 0;
     for (let i = 0; i < this.months.length; i++) {
-      const month = this.months[i];
-      if (currentMonth.month === month.month) {
+      if (currentMonth.month === this.months[i].month) {
         currentMonthIdx = i;
       }
     }
@@ -200,8 +199,7 @@ export class YnabComponent implements OnInit {
       case 'yr':
         // Go to current month, work backwards to prev Dec, then calc from there. 
         for (let i = currentMonthIdx + 1; i < this.months.length; i++) { //Note: Adding 1 to current month, in case this is december. We would want last year's december
-          const month = this.months[i];
-          if (month.month.endsWith('-12-01')) {
+          if (this.months[i].month.endsWith('-12-01')) {
             let startMonthIdx = Math.min(i+11, this.months.length-1) //Don't go too far into past
             await this.selectMonths(this.months[startMonthIdx].month, this.months[i].month);
             break;
@@ -215,8 +213,7 @@ export class YnabComponent implements OnInit {
       case 'ytd':
         // Go to current month, work backwards to prev Jan.
         for (let i = currentMonthIdx; i < this.months.length; i++) {
-          const month = this.months[i];
-          if (month.month.endsWith('-01-01')) {
+          if (this.months[i].month.endsWith('-01-01')) {
             await this.selectMonths(this.months[i].month, currentMonth.month);
             break;
           }


### PR DESCRIPTION
Mostly see title. 

Adding some common choices when selecting months. Easy to add more if any are wanted. 

![image](https://user-images.githubusercontent.com/1266676/109741271-b82bf280-7b9a-11eb-9659-8ba6c6480a93.png)

![image](https://user-images.githubusercontent.com/1266676/109741301-c7ab3b80-7b9a-11eb-911e-8ca503ca36bd.png)

Small notes: 
- Didn't support a zero month budget, can't imagine that happening since you can't delete months and the budget will auto create with one.
- Selecting an option that is out of range (e.g. "Last Year" when you didn't have YNAB last year) should result in no action. 
- Default was left at current month only. 