### PR TITLE
Fixed PWA theme colors and title

### DIFF
--- a/src/assets/site.webmanifest
+++ b/src/assets/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Beyond Rule 4",
-  "short_name": "Beyond4",
+  "name": "Beyond Rule 4 - YNAB and Financial Independence (FIRE)",
+  "short_name": "Beyond Rule 4",
   "icons": [
     {
       "src": "/assets/web-app-manifest-192x192.png",
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#18BC9C",
-  "background_color": "#18BC9C",
+  "theme_color": "#ecf0f1",
+  "background_color": "#ecf0f1",
   "display": "standalone"
 }

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
   <link rel="shortcut icon" href="assets/favicon.ico" />
   <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png" />
-  <meta name="apple-mobile-web-app-title" content="Beyond4" />
+  <meta name="apple-mobile-web-app-title" content="Beyond Rule 4" />
   <link rel="manifest" href="assets/site.webmanifest" />
 
   <!-- Load environment variables -->


### PR DESCRIPTION
# PWA Styling

Follow up for PR https://github.com/JackMorrissey/beyond-rule-4/pull/88 with small visual improvements.

## Title
Initially, I created a short title called `Beyond4` to be displayed on mobile devices, since I thought `Beyond Rule 4` was too long to be displayed. Turns out it would work just fine on two test devices (iPhone 12 Pro and Pixel 8). Also the users has the ability to customize the name of the shortcut, so I guess it's better to stick to the full name as default.

## Colors
Turns out, it would look more polished with the status bar and background being gray `#ecf0f1` instead of the poppy green `#18BC9C`.