### PR TITLE
Add birthdate input and age calculations

### DIFF
--- a/src/app/forecasting/input/ynab/birthdate-utility.ts
+++ b/src/app/forecasting/input/ynab/birthdate-utility.ts
@@ -1,0 +1,31 @@
+export type Birthdate = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+/**
+ * Converts a Birthdate object to a JavaScript Date object.
+ * @param birthdate The Birthdate object to convert.
+ * @returns A Date object representing the same date.
+ */
+export function birthdateToDate(birthdate: Birthdate): Date {
+  try {
+    return new Date(birthdate.year, birthdate.month - 1, birthdate.day);
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Converts a JavaScript Date object to a Birthdate object.
+ * @param date The Date object to convert.
+ * @returns A Birthdate object representing the same date.
+ */
+export function dateToBirthdate(date: Date): Birthdate {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1, // Months are 0-based in JavaScript
+    day: date.getDate(),
+  };
+}

--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -178,9 +178,19 @@
                 <label for="birthdate" class="col-sm-12 col-md-5 col-form-label">Birthdate</label>
                 <div class="col">
                   <div class="input-group">
-                    <input type="date" class="form-control" id="birthdate"
-                    formControlName="birthdate"
-                    aria-describedby="birthdateHelp" />
+                    <input
+                      class="form-control"
+                      id="ngBirthDate"
+                      formControlName="birthdate"
+                      ngbDatepicker
+                      #d="ngbDatepicker"
+                      [minDate]="{ year: 1900, month: 1, date: 1 }"
+                      placeholder="yyyy-mm-dd"
+                      [readonly]="false"
+                    />
+                    <div class="input-group-append">
+                      <button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -174,6 +174,16 @@
                   </div>
                 </div>
               </div>
+              <div class="row mb-3">
+                <label for="birthdate" class="col-sm-12 col-md-5 col-form-label">Birthdate</label>
+                <div class="col">
+                  <div class="input-group">
+                    <input type="date" class="form-control" id="birthdate"
+                    formControlName="birthdate"
+                    aria-describedby="birthdateHelp" />
+                  </div>
+                </div>
+              </div>
             </div>
           </ng-template>
         </div>

--- a/src/app/forecasting/input/ynab/ynab.component.ts
+++ b/src/app/forecasting/input/ynab/ynab.component.ts
@@ -10,14 +10,14 @@ import { CalculateInput } from '../../models/calculate-input.model';
 import { round } from '../../utilities/number-utility';
 import CategoryUtility from './category-utility';
 import NoteUtility, { Overrides } from './note-utility';
+import { Birthdate } from './birthdate-utility';
 import { getSelectedMonths, QuickSelectMonthChoice } from './months-utility';
-import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 @Component({
     selector: 'app-ynab',
     templateUrl: 'ynab.component.html',
     styleUrls: ['./ynab.component.css'],
-    standalone: false
+    standalone: false,
 })
 export class YnabComponent implements OnInit {
   @Output() calculateInputChange = new EventEmitter<CalculateInput>();
@@ -58,7 +58,7 @@ export class YnabComponent implements OnInit {
   };
   public contributionCategories: any;
   public isUsingSampleData = false;
-  public birthdate : Date;
+  public birthdate: Birthdate;
 
   constructor(
     private ynabService: YnabApiService,
@@ -100,14 +100,10 @@ export class YnabComponent implements OnInit {
       this.expectedAnnualGrowthRate = expectedAnnualGrowthRateStorage;
     }
 
-    const birthdateStorage = new Date(
-      window.localStorage.getItem('br4-birthdate')
-    );
-    if (
-      !!birthdateStorage &&
-      !birthdateStorage
-    ) {
-      this.birthdate = birthdateStorage;
+    try {
+      this.birthdate = JSON.parse(window.localStorage.getItem('br4-birthdate'));
+    } catch {
+      this.birthdate = null;
     }
 
     this.budgetForm = this.formBuilder.group({
@@ -126,7 +122,7 @@ export class YnabComponent implements OnInit {
         this.expectedAnnualGrowthRate,
         [Validators.required, Validators.max(99.99), Validators.max(0.01)],
       ],
-      birthdate: ['', [Validators.required]],
+      birthdate: [this.birthdate, [Validators.required]],
     });
   }
 
@@ -341,11 +337,9 @@ export class YnabComponent implements OnInit {
 
     this.handlePercentageFormChanges();
 
-    const birthdate = this.budgetForm.value.birthdate;
-    if (this.birthdate !== birthdate) {
-      this.birthdate = birthdate;
-      window.localStorage.setItem('br4-birthdate', birthdate);
-    }
+    
+    this.birthdate = this.budgetForm.value.birthdate;
+    window.localStorage.setItem('br4-birthdate', JSON.stringify(this.birthdate));
 
     const selectedBudget = this.budgetForm.value.selectedBudget;
     if (this.budget.id !== selectedBudget) {
@@ -365,8 +359,6 @@ export class YnabComponent implements OnInit {
       );
       return;
     }
-
-
 
     this.recalculate();
   }

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -12,6 +12,7 @@ export class CalculateInput {
   currencyIsoCode = 'USD';
   monthFromName = '';
   monthToName = '';
+  birthdate = new Date();
 
   public constructor(init?: Partial<CalculateInput>) {
     Object.assign(

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -1,3 +1,4 @@
+import { Birthdate } from '../input/ynab/birthdate-utility';
 import { round } from '../utilities/number-utility';
 
 export class CalculateInput {
@@ -12,7 +13,7 @@ export class CalculateInput {
   currencyIsoCode = 'USD';
   monthFromName = '';
   monthToName = '';
-  birthdate = new Date();
+  birthdate: Birthdate = null;
 
   public constructor(init?: Partial<CalculateInput>) {
     Object.assign(

--- a/src/app/forecasting/models/forecast.model.ts
+++ b/src/app/forecasting/models/forecast.model.ts
@@ -18,22 +18,29 @@ export class Forecast {
   }
 
   public getDistanceFromFirstMonthText(forecastDate: Date): string {
+    const inPast = forecastDate < this.month0Date;
+    const difference = this.getDistanceFromDateText(forecastDate, this.month0Date);
+    const suffix = inPast ? 'ago' : '';
+    return difference + suffix;
+  }
+
+  public getDistanceFromDateText(forecastDate: Date, fromDate: Date): string {
+    if (!forecastDate || !fromDate) {
+      return;
+    }
+
     let monthDifference =
-      ((forecastDate.getFullYear() - this.month0Date.getFullYear()) * 12)
-      + (forecastDate.getMonth() - this.month0Date.getMonth());
+      ((forecastDate.getFullYear() - fromDate.getFullYear()) * 12)
+      + (forecastDate.getMonth() - fromDate.getMonth());
 
     if (monthDifference === 0) {
       return;
     }
 
-    const inPast = monthDifference < 0;
     monthDifference = Math.abs(monthDifference);
-
     const months = monthDifference % 12;
     const years = (monthDifference - months) / 12;
-    const difference = this.getTimeString(years, 'year') + this.getTimeString(months, 'month');
-    const suffix = inPast ? 'ago' : '';
-    return difference + suffix;
+    return this.getTimeString(years, 'year') + this.getTimeString(months, 'month');
   }
 
   private getTimeString(timeDifference: number, unit: string): string {

--- a/src/app/forecasting/models/forecast.model.ts
+++ b/src/app/forecasting/models/forecast.model.ts
@@ -1,9 +1,11 @@
 import { CalculateInput } from './calculate-input.model';
 import { round } from '../utilities/number-utility';
+import { Birthdate } from '../input/ynab/birthdate-utility';
 
 export class Forecast {
   monthlyForecasts: MonthlyForecast[];
   month0Date: Date;
+  birthdate: Birthdate;
 
   public constructor(calculateInput: CalculateInput, month0Date?: Date) {
     if (!calculateInput) {
@@ -12,6 +14,7 @@ export class Forecast {
     if (!this.month0Date) {
       this.month0Date = new Date();
     }
+    this.birthdate = calculateInput.birthdate;
     this.month0Date.setDate(1); // make it the first of the month
     this.computeForecast(calculateInput);
     this.setDates();
@@ -21,7 +24,7 @@ export class Forecast {
     const inPast = forecastDate < this.month0Date;
     const difference = this.getDistanceFromDateText(forecastDate, this.month0Date);
     const suffix = inPast ? 'ago' : '';
-    return difference + suffix;
+    return difference ? difference + suffix: undefined;
   }
 
   public getDistanceFromDateText(forecastDate: Date, fromDate: Date): string {
@@ -109,6 +112,7 @@ export class Forecast {
 export class MonthlyForecast {
   monthIndex: number;
   date: Date;
+  age: Date;
   netWorth: number;
   lastMonthNetWorth: number;
   contribution: number;

--- a/src/app/forecasting/output/fi-text/fi-text.component.html
+++ b/src/app/forecasting/output/fi-text/fi-text.component.html
@@ -3,6 +3,7 @@
     <h4 class="fw-light">FI Date</h4>
     <h2>
       <strong>{{ fiDate }}</strong> • {{ dateDistance }}
+      <span *ngIf="fiAge !== undefined">• {{ fiAge }} old</span>
     </h2>
     <hr />
     <ul class="list-inline mb-0">
@@ -11,7 +12,9 @@
       </li>
       <li class="list-inline-item"></li>
       <li class="list-inline-item">
-        <h4>{{ leanFiDate }} • {{ leanFiDateDistance }}</h4>
+        <h4>{{ leanFiDate }} • {{ leanFiDateDistance }}
+          <span *ngIf="leanFiAge !== undefined">• {{ leanFiAge }} old</span>
+        </h4>
       </li>
     </ul>
   </div>

--- a/src/app/forecasting/output/fi-text/fi-text.component.html
+++ b/src/app/forecasting/output/fi-text/fi-text.component.html
@@ -3,7 +3,7 @@
     <h4 class="fw-light">FI Date</h4>
     <h2>
       <strong>{{ fiDate }}</strong> • {{ dateDistance }}
-      <span *ngIf="fiAge !== undefined">• {{ fiAge }} old</span>
+      <span *ngIf="fiAge !== null" class="fst-italic">• {{ fiAge }} old</span>
     </h2>
     <hr />
     <ul class="list-inline mb-0">
@@ -13,7 +13,7 @@
       <li class="list-inline-item"></li>
       <li class="list-inline-item">
         <h4>{{ leanFiDate }} • {{ leanFiDateDistance }}
-          <span *ngIf="leanFiAge !== undefined">• {{ leanFiAge }} old</span>
+          <span *ngIf="leanFiAge !== null" class="fst-italic">• {{ leanFiAge }} old</span>
         </h4>
       </li>
     </ul>
@@ -42,6 +42,7 @@
       At <strong>{{ expectedAnnualGrowthRate }}%</strong> returns, that Net
       Worth is forecasted to be <strong>{{ fiDate }}</strong
       >; {{ dateDistance }} from the first month.
+      <span *ngIf="fiAge !== null">You'll be <strong>{{ fiAge }}</strong> old at that time.</span>
       <span *ngIf="fiMonthForecast">
         By that point, Net Worth is at
         <strong>{{

--- a/src/app/forecasting/output/fi-text/fi-text.component.ts
+++ b/src/app/forecasting/output/fi-text/fi-text.component.ts
@@ -7,14 +7,14 @@ import {
 } from '@angular/core';
 
 import { round } from '../../utilities/number-utility';
-
+import { birthdateToDate } from '../../input/ynab/birthdate-utility';
 import { CalculateInput } from '../../models/calculate-input.model';
 import { Forecast, MonthlyForecast } from '../../models/forecast.model';
 
 @Component({
-    selector: 'app-fi-text',
-    templateUrl: 'fi-text.component.html',
-    standalone: false
+  selector: 'app-fi-text',
+  templateUrl: 'fi-text.component.html',
+  standalone: false,
 })
 export class FiTextComponent implements OnInit, OnChanges {
   @Input() calculateInput: CalculateInput;
@@ -65,6 +65,8 @@ export class FiTextComponent implements OnInit, OnChanges {
     const foundFiForecast = this.forecast.monthlyForecasts.find(
       (f) => f.netWorth >= fiNumber
     );
+    const birthdate = birthdateToDate(this.calculateInput.birthdate);
+
     if (!foundFiForecast) {
       this.fiDate = 'Never';
       this.dateDistance = 'Forever';
@@ -76,7 +78,9 @@ export class FiTextComponent implements OnInit, OnChanges {
         this.forecast.getDistanceFromFirstMonthText(foundFiForecast.date) ||
         '0 Months';
       this.fiMonthForecast = foundFiForecast;
-        this.fiAge = this.forecast.getDistanceFromDateText(foundFiForecast.date, this.calculateInput.birthdate);
+      this.fiAge = birthdate && !isNaN(birthdate.getTime())
+        ? this.forecast.getDistanceFromDateText(foundFiForecast.date, birthdate)
+        : null;
     }
 
     const foundLeanFiForecast = this.forecast.monthlyForecasts.find(
@@ -91,7 +95,12 @@ export class FiTextComponent implements OnInit, OnChanges {
       this.leanFiDateDistance =
         this.forecast.getDistanceFromFirstMonthText(foundLeanFiForecast.date) ||
         '0 Months';
-      this.leanFiAge = this.forecast.getDistanceFromDateText(foundLeanFiForecast.date, this.calculateInput.birthdate);
+      this.leanFiAge = birthdate && !isNaN(birthdate.getTime())
+        ? this.forecast.getDistanceFromDateText(
+            foundLeanFiForecast.date,
+            birthdate
+          )
+        : null;
     }
   }
 }

--- a/src/app/forecasting/output/fi-text/fi-text.component.ts
+++ b/src/app/forecasting/output/fi-text/fi-text.component.ts
@@ -27,10 +27,12 @@ export class FiTextComponent implements OnInit, OnChanges {
   fiMonthForecast: MonthlyForecast;
   fiDate: string;
   dateDistance: string;
+  fiAge: string;
 
   leanFiNumber: number;
   leanFiDate: string;
   leanFiDateDistance: string;
+  leanFiAge: string;
 
   constructor() {}
 
@@ -67,12 +69,14 @@ export class FiTextComponent implements OnInit, OnChanges {
       this.fiDate = 'Never';
       this.dateDistance = 'Forever';
       this.fiMonthForecast = undefined;
+      this.fiAge = undefined;
     } else {
       this.fiDate = foundFiForecast.toDateString();
       this.dateDistance =
         this.forecast.getDistanceFromFirstMonthText(foundFiForecast.date) ||
         '0 Months';
       this.fiMonthForecast = foundFiForecast;
+        this.fiAge = this.forecast.getDistanceFromDateText(foundFiForecast.date, this.calculateInput.birthdate);
     }
 
     const foundLeanFiForecast = this.forecast.monthlyForecasts.find(
@@ -81,11 +85,13 @@ export class FiTextComponent implements OnInit, OnChanges {
     if (!foundLeanFiForecast) {
       this.leanFiDate = 'Never';
       this.leanFiDateDistance = 'Forever';
+      this.leanFiAge = undefined;
     } else {
       this.leanFiDate = foundLeanFiForecast.toDateString();
       this.leanFiDateDistance =
         this.forecast.getDistanceFromFirstMonthText(foundLeanFiForecast.date) ||
         '0 Months';
+      this.leanFiAge = this.forecast.getDistanceFromDateText(foundLeanFiForecast.date, this.calculateInput.birthdate);
     }
   }
 }

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -44,7 +44,7 @@ export class ImpactComponent implements OnInit, OnChanges {
         });
 
         this.spendingCategoriesWithImpact = categoriesWithSpending.map((category) => {
-            const isFi = !this.forecast.getDistanceFromFirstMonthText(currentFiForecast.date);
+            const isFi = currentFiForecast.date < new Date();
 
             let impactDate = 'Achieved FI!';
             if (isFi) {

--- a/src/app/forecasting/output/milestones/text/text.component.html
+++ b/src/app/forecasting/output/milestones/text/text.component.html
@@ -6,6 +6,7 @@
         <th>Net Worth</th>
         <th>Forecast Date</th>
         <th>Distance</th>
+        <th *ngIf="forecast.birthdate != null">Age</th>
         <th>Contributions</th>
         <th>Returns</th>
       </tr>
@@ -16,6 +17,7 @@
         <td>{{ m.milestone.value | currency:currencyIsoCode:'symbol':'1.0'}}</td>
         <td>{{ m.forecastDate }}</td>
         <td>{{ m.distance }}</td>
+        <td *ngIf="forecast.birthdate">{{ m.age }}</td>
         <td>{{ m.forecast?.totalContributions | currency:currencyIsoCode:'symbol':'1.0-0'}}</td>
         <td>{{ m.forecast?.totalReturns | currency:currencyIsoCode:'symbol':'1.0-0'}}</td>
       </tr>

--- a/src/app/forecasting/output/milestones/text/text.component.ts
+++ b/src/app/forecasting/output/milestones/text/text.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, Input, OnChanges, SimpleChanges, } from '@angular/co
 import { CalculateInput } from '../../../models/calculate-input.model';
 import { Forecast, MonthlyForecast } from '../../../models/forecast.model';
 import { Milestones } from '../milestone.model';
+import { birthdateToDate } from '../../../input/ynab/birthdate-utility';
 
 @Component({
     selector: 'app-milestones-text',
@@ -55,12 +56,14 @@ export class TextComponent implements OnInit, OnChanges {
       const forecast = forecastSearch[foundIndex];
       const forecastDate = this.getDateString(forecast.date);
       const distance = this.getDistanceText(forecast.date);
+      const age = this.forecast.getDistanceFromDateText(forecast.date, birthdateToDate(this.forecast.birthdate));
       const completed = distance === this.completeText;
       return {
         milestone,
         forecast,
         forecastDate,
         distance,
+        age,
         completed
       };
     });
@@ -76,10 +79,6 @@ export class TextComponent implements OnInit, OnChanges {
   }
 
   getDistanceText(forecastDate: Date) {
-    const text = this.forecast.getDistanceFromFirstMonthText(forecastDate);
-    if (!text) {
-      return this.completeText;
-    }
-    return text;
+    return this.forecast.getDistanceFromFirstMonthText(forecastDate) ?? this.completeText;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="Beyond Rule 4" />
   <link rel="manifest" id="manifest-placeholder" />
-
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" />
   <!-- Load environment variables -->
   <script src="assets/env.js"></script>
 


### PR DESCRIPTION
closing issue 16: https://github.com/JackMorrissey/beyond-rule-4/issues/16 and integrated comments from PR 17: https://github.com/JackMorrissey/beyond-rule-4/pull/17. eg. using the ng-bootstrap calendar

Introduce a birthdate input field and implement related calculations for age within the forecasting module. This enhancement allows users to input their birthdate, enabling the application to compute and display age in relevant contexts.

