### PR TITLE
feat(ynab): add timeframe indicators to accordion titles

### DIFF
--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -382,9 +382,10 @@
       <h2 ngbAccordionHeader>
         <button ngbAccordionButton>
           <span class="float-start">Contributions</span>
-          <span class="ms-auto">{{
-            budgetForm.value.monthlyContribution | currency : currencyIsoCode
-          }}</span>
+          <span class="ms-auto text-end">
+            {{ budgetForm.value.monthlyContribution * 12 | currency : currencyIsoCode }} per year
+            <small class="opacity-75 d-block mt-1">{{ budgetForm.value.monthlyContribution | currency : currencyIsoCode }} per month</small>
+          </span>
         </button>
       </h2>
 
@@ -519,9 +520,10 @@
       <h2 ngbAccordionHeader>
         <button ngbAccordionButton>
           <span class="float-start">Expenses</span>
-          <span class="ms-auto">
-            {{ expenses.fi.annual | currency : currencyIsoCode }}</span
-          >
+          <span class="ms-auto text-end">
+            {{ expenses.fi.annual | currency : currencyIsoCode }} per year
+            <small class="opacity-75 d-block mt-1">{{ expenses.fi.monthly | currency : currencyIsoCode }} per month</small>
+          </span>
         </button>
       </h2>
       <div ngbAccordionCollapse>


### PR DESCRIPTION
## Summary
- Add annual and monthly frequency indicators to Contributions and Expenses accordion titles
- Display annual value prominently with monthly value in smaller, muted text below
- Provides clearer context for users about the time period of displayed amounts

Closes #119

## Test plan
- [ ] Run `ng serve` and navigate to the FI Forecast page
- [ ] Connect to YNAB or use sample data
- [ ] Verify Contributions accordion shows `$X,XXX per year` with `$X,XXX per month` below
- [ ] Verify Expenses accordion shows `$XX,XXX per year` with `$X,XXX per month` below
- [ ] Verify Starting Portfolio remains unchanged (one-time balance, no frequency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)