### PR TITLE
feat(milestones): add tooltips to FI Milestones table

### DIFF
--- a/src/app/forecasting/output/milestones/text/text.component.html
+++ b/src/app/forecasting/output/milestones/text/text.component.html
@@ -13,7 +13,11 @@
     </thead>
     <tbody>
       <tr *ngFor="let m of milestonesWithForecast" [ngClass]="{'table-success' : m.completed}">
-        <td>{{ m.milestone.label }}</td>
+        <td
+          [ngbTooltip]="getMilestoneTooltip(m.milestone.label)"
+          placement="top"
+          container="body"
+        >{{ m.milestone.label }}</td>
         <td>{{ m.milestone.value | currency:currencyIsoCode:'symbol':'1.0'}}</td>
         <td>{{ m.forecastDate }}</td>
         <td>{{ m.distance }}</td>

--- a/src/app/forecasting/output/milestones/text/text.component.ts
+++ b/src/app/forecasting/output/milestones/text/text.component.ts
@@ -81,4 +81,18 @@ export class TextComponent implements OnInit, OnChanges {
   getDistanceText(forecastDate: Date) {
     return this.forecast.getDistanceFromFirstMonthText(forecastDate) ?? this.completeText;
   }
+
+  getMilestoneTooltip(label: string): string {
+    const tooltips: { [key: string]: string } = {
+      'FU$': 'F-You Money: 10% of your FI number (2.5x annual expenses)',
+      'Half FI': 'Halfway to Financial Independence (12.5x annual expenses)',
+      'Lean FI': 'Financially independent with a lean budget',
+      'Flex FI': 'Flexible FI: 80% of your FI number (20x annual expenses)',
+      'FI': 'Financial Independence: 25x annual expenses using the 4% rule',
+      'Fat FI': 'Fat FI: 120% of your FI number (30x annual expenses)',
+      '1.5x FI': '1.5 times your FI number for extra security',
+      'Contribution / Returns Eclipse': 'The point where investment returns exceed your contributions'
+    };
+    return tooltips[label] || '';
+  }
 }


### PR DESCRIPTION
## Summary
- Add tooltips to each milestone label in the FI Milestones table
- Tooltips explain what each milestone represents (FU$, Half FI, Lean FI, Flex FI, FI, Fat FI, 1.5x FI, and Contribution/Returns Eclipse)
- Helps users understand the financial independence milestones

Closes #114

## Test plan
- [ ] Run `ng serve` and navigate to the FI Forecast page
- [ ] Connect to YNAB or use sample data
- [ ] Hover over each milestone label in the table
- [ ] Verify tooltips appear with appropriate descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)