### PR TITLE
feat(ynab): add reload budget button

### DIFF
--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -36,6 +36,19 @@
                         {{ budget.name }}
                       </option>
                     </select>
+                    <button
+                      type="button"
+                      class="btn btn-outline-secondary"
+                      (click)="reloadBudget()"
+                      [disabled]="isReloadingBudget || !budget"
+                      ngbTooltip="Reload budget and reset adjustments"
+                      placement="top"
+                    >
+                      <fa-icon
+                        [icon]="['fas', 'sync']"
+                        [animation]="isReloadingBudget ? 'spin' : undefined"
+                      ></fa-icon>
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/app/forecasting/input/ynab/ynab.component.ts
+++ b/src/app/forecasting/input/ynab/ynab.component.ts
@@ -58,6 +58,7 @@ export class YnabComponent implements OnInit {
   };
   public contributionCategories: any;
   public isUsingSampleData = false;
+  public isReloadingBudget = false;
   public birthdate: Birthdate;
 
   constructor(
@@ -235,6 +236,20 @@ export class YnabComponent implements OnInit {
       'previousChoice'
     );
     await this.selectMonths(selectedMonths.from.month, selectedMonths.to.month);
+  }
+
+  async reloadBudget(): Promise<void> {
+    if (!this.budget || this.isReloadingBudget) {
+      return;
+    }
+    this.isReloadingBudget = true;
+    try {
+      await this.selectBudget(this.budget.id);
+    } catch (error) {
+      console.error('Failed to reload budget:', error);
+    } finally {
+      this.isReloadingBudget = false;
+    }
   }
 
   toggleIncludeHiddenYnabCategories(newValue: boolean) {


### PR DESCRIPTION
## Summary
- Add a "Reload Budget" button next to the budget dropdown selector
- Reloads budget data from YNAB API and resets all manual UI adjustments
- Button shows spinning sync icon during reload and is disabled when no budget is selected

Closes #115

## Test plan
- [ ] Run `npm start` and open the app
- [ ] Authorize with YNAB and select a budget
- [ ] Make manual adjustments to account balances, contributions, or expenses
- [ ] Click the reload button (sync icon next to budget dropdown)
- [ ] Verify icon spins during reload
- [ ] Verify all manual adjustments reset to YNAB-computed values
- [ ] Verify button is disabled when no budget is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)