### PR TITLE
feat: add external contributions and lump sum adjustments to FI number

### DIFF
--- a/src/app/forecasting/input/ynab/ynab.component.html
+++ b/src/app/forecasting/input/ynab/ynab.component.html
@@ -228,6 +228,64 @@
             <div class="form-group">
               <div class="row">
                 <label
+                  for="expectedExternalAnnualContributions"
+                  class="col-sm-12 col-md-5 col-form-label"
+                  >Expected External Annual Contributions</label
+                >
+                <div class="col">
+                  <div class="input-group">
+                    <input
+                      type="number"
+                      class="form-control"
+                      id="expectedExternalAnnualContributions"
+                      formControlName="expectedExternalAnnualContributions"
+                      step="100"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col">
+                  <small
+                    >Annual income expected in retirement from external sources
+                    (e.g., pension, social security). This reduces your FI
+                    target.</small
+                  >
+                </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="row">
+                <label
+                  for="additionalLumpSumNeeded"
+                  class="col-sm-12 col-md-5 col-form-label"
+                  >Additional Lump Sum Needed</label
+                >
+                <div class="col">
+                  <div class="input-group">
+                    <input
+                      type="number"
+                      class="form-control"
+                      id="additionalLumpSumNeeded"
+                      formControlName="additionalLumpSumNeeded"
+                      step="1000"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col">
+                  <small
+                    >One-time amount needed at retirement (e.g., pay off
+                    mortgage, major purchase). This increases your FI
+                    target.</small
+                  >
+                </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="row">
+                <label
                   for="expectedAnnualGrowthRate"
                   class="col-sm-12 col-md-5 col-form-label"
                   >Expected Annual Rate of Return</label

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -15,6 +15,8 @@ export class CalculateInput {
   monthFromName = '';
   monthToName = '';
   birthdate: Birthdate = null;
+  expectedExternalAnnualContributions = 0;
+  additionalLumpSumNeeded = 0;
 
   // Time series for dynamic values
   monthlyContributionSeries: TimeSeries | null = null;
@@ -42,22 +44,30 @@ export class CalculateInput {
     this.monthlyContribution = round(this.monthlyContribution);
     this.leanFiPercentage = round(this.leanFiPercentage);
     this.leanAnnualExpenses = round(this.leanAnnualExpenses);
+    this.expectedExternalAnnualContributions = round(this.expectedExternalAnnualContributions);
+    this.additionalLumpSumNeeded = round(this.additionalLumpSumNeeded);
   }
 
   get safeWithdrawalTimes() {
     return 1 / this.annualSafeWithdrawalRate;
   }
 
+  get externalContributionReduction() {
+    return this.safeWithdrawalTimes * this.expectedExternalAnnualContributions;
+  }
+
   get fiNumber() {
-    return this.safeWithdrawalTimes * this.annualExpenses;
+    const baseFi = this.safeWithdrawalTimes * this.annualExpenses;
+    return baseFi - this.externalContributionReduction + this.additionalLumpSumNeeded;
   }
 
   get leanFiNumber() {
-    let leanFiNumber = this.fiNumber * this.leanFiPercentage;
+    let baseLeanFi = this.fiNumber * this.leanFiPercentage;
     if (this.leanAnnualExpenses) {
-      leanFiNumber = this.safeWithdrawalTimes * this.leanAnnualExpenses;
+      baseLeanFi = this.safeWithdrawalTimes * this.leanAnnualExpenses;
+      baseLeanFi = baseLeanFi - this.externalContributionReduction + this.additionalLumpSumNeeded;
     }
-    return leanFiNumber;
+    return baseLeanFi;
   }
 
   /**

--- a/src/app/forecasting/output/fi-text/fi-text.component.html
+++ b/src/app/forecasting/output/fi-text/fi-text.component.html
@@ -29,11 +29,21 @@
       <strong>{{
         calculateInput.annualExpenses | currency: calculateInput.currencyIsoCode
       }}</strong
+      ><span *ngIf="calculateInput.monthFromName != calculateInput.monthToName"
+        >, between {{ calculateInput.monthFromName }} and
+        {{ calculateInput.monthToName }}</span
+      ><span *ngIf="externalContributions > 0"
+        >, and expected external contributions of
+        <strong>{{
+          externalContributions | currency: calculateInput.currencyIsoCode
+        }}</strong
+        >/year</span
+      ><span *ngIf="additionalLumpSum > 0"
+        >, plus an additional lump sum of
+        <strong>{{
+          additionalLumpSum | currency: calculateInput.currencyIsoCode
+        }}</strong></span
       >,
-      <span *ngIf="calculateInput.monthFromName != calculateInput.monthToName"
-        >between {{ calculateInput.monthFromName }} and
-        {{ calculateInput.monthToName }},
-      </span>
       we're aiming for a Net Worth of
       <strong>{{ fiNumber | currency: calculateInput.currencyIsoCode }}</strong
       >.

--- a/src/app/forecasting/output/fi-text/fi-text.component.ts
+++ b/src/app/forecasting/output/fi-text/fi-text.component.ts
@@ -34,6 +34,10 @@ export class FiTextComponent implements OnInit, OnChanges {
   leanFiDateDistance: string;
   leanFiAge: string;
 
+  externalContributions: number;
+  externalContributionReduction: number;
+  additionalLumpSum: number;
+
   constructor() {}
 
   ngOnInit() {}
@@ -57,6 +61,10 @@ export class FiTextComponent implements OnInit, OnChanges {
 
     const leanFiNumber = Math.max(0, round(this.calculateInput.leanFiNumber));
     this.leanFiNumber = leanFiNumber;
+
+    this.externalContributions = round(this.calculateInput.expectedExternalAnnualContributions);
+    this.externalContributionReduction = round(this.calculateInput.externalContributionReduction);
+    this.additionalLumpSum = round(this.calculateInput.additionalLumpSumNeeded);
 
     if (!this.forecast) {
       return;


### PR DESCRIPTION
## Summary

- Add settings for expected external annual contributions (pensions, social security) that reduce the FI target
- Add settings for additional lump sum needed (e.g., pay off mortgage) that increases the FI target
- Values persist in localStorage and are displayed in the FI explanation text

**Example:**
- Before: "With annual expenses of $40,148, we're aiming for a Net Worth of $1,003,713"
- After: "With annual expenses of $40,148, and expected external contributions of $12,000/year, we're aiming for a Net Worth of $703,713"

**Math:** $12k/year external income × 25 (at 4% SWR) = $300k reduction in FI target.

Closes #12

## Test plan

- [ ] Run `npm start` and load sample data
- [ ] In Settings, enter $12,000 for external contributions
- [ ] Verify FI number decreases by ~$300,000 (at 4% SWR)
- [ ] Enter $200,000 for additional lump sum
- [ ] Verify FI number increases by $200,000
- [ ] Refresh page - verify values persist
- [ ] Run `npm run build` to verify production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)