### PR TITLE
Birthdate validation, CoastFI text fix, CoastFI Net Worth in chart fix, etc.

### DIFF
--- a/src/app/forecasting/input/ynab/birthdate-utility.ts
+++ b/src/app/forecasting/input/ynab/birthdate-utility.ts
@@ -11,7 +11,8 @@ export type Birthdate = {
  */
 export function birthdateToDate(birthdate: Birthdate): Date {
   try {
-    return new Date(birthdate.year, birthdate.month - 1, birthdate.day);
+    const b = new Date(birthdate.year, birthdate.month - 1, birthdate.day);
+    return !isNaN(b.getTime()) ? b : null;
   } catch (e) {
     return null;
   }
@@ -23,9 +24,9 @@ export function birthdateToDate(birthdate: Birthdate): Date {
  * @returns A Birthdate object representing the same date.
  */
 export function dateToBirthdate(date: Date): Birthdate {
-  return {
+  return !isNaN(date.getTime()) ? {
     year: date.getFullYear(),
     month: date.getMonth() + 1, // Months are 0-based in JavaScript
     day: date.getDate(),
-  };
+  } : null;
 }

--- a/src/app/forecasting/input/ynab/ynab.component.ts
+++ b/src/app/forecasting/input/ynab/ynab.component.ts
@@ -1131,7 +1131,7 @@ export class YnabComponent implements OnInit {
     if (categoryGroups) {
       categoryGroups.forEach((cg) => {
         cg.categories.forEach((c) => {
-          if (c.contributionBudget) {
+          if (c.contributionBudget != null) {
             contribution += c.contributionBudget;
             categories.push({
               name: c.name,
@@ -1164,7 +1164,7 @@ export class YnabComponent implements OnInit {
     if (accounts) {
       accounts.forEach((a) => {
         const monthlyContribution = a.value.monthlyContribution;
-        if (monthlyContribution) {
+        if (monthlyContribution != null) {
           contribution += monthlyContribution;
           categories.push({
             name: a.value.name,

--- a/src/app/forecasting/input/ynab/ynab.component.ts
+++ b/src/app/forecasting/input/ynab/ynab.component.ts
@@ -587,6 +587,8 @@ export class YnabComponent implements OnInit {
       for (const category of categoryGroup.categories) {
         // Check contribution schedules
         const contributionSchedule = category.contributionBudgetSchedule;
+        let lastContribution = category.contributionBudget || 0;
+        
         if (contributionSchedule?.schedule?.length > 0) {
           for (const point of contributionSchedule.schedule) {
             const id = `${category.name}-contribution-${point.effectiveDate}`;
@@ -595,16 +597,20 @@ export class YnabComponent implements OnInit {
               categoryName: category.name,
               categoryId: category.name, // Using name as ID since it's more stable
               type: 'contribution',
-              baselineValue: category.contributionBudget || 0,
+              baselineValue: lastContribution,
               scheduledValue: point.value,
               effectiveDate: point.effectiveDate,
               enabled: !this.disabledChangeIds.has(id),
             });
+
+            lastContribution = point.value;
           }
         }
 
         // Check FI budget schedules
         const fiBudgetSchedule = category.computedFiBudgetSchedule;
+        let lastFiExpense = category.fiBudget || category.computedFiBudget || 0;
+        
         if (fiBudgetSchedule?.schedule?.length > 0) {
           for (const point of fiBudgetSchedule.schedule) {
             const id = `${category.name}-fiBudget-${point.effectiveDate}`;
@@ -613,17 +619,20 @@ export class YnabComponent implements OnInit {
               categoryName: category.name,
               categoryId: category.name,
               type: 'fiBudget',
-              baselineValue:
-                category.fiBudget || category.computedFiBudget || 0,
+              baselineValue: lastFiExpense,
               scheduledValue: point.value,
               effectiveDate: point.effectiveDate,
               enabled: !this.disabledChangeIds.has(id),
             });
+
+            lastFiExpense = point.value;
           }
         }
 
         // Check Lean FI budget schedules
         const leanFiBudgetSchedule = category.computedLeanFiBudgetSchedule;
+        let lastLeanFiExpense = category.leanFiBudget || category.computedLeanFiBudget || 0;
+
         if (leanFiBudgetSchedule?.schedule?.length > 0) {
           for (const point of leanFiBudgetSchedule.schedule) {
             const id = `${category.name}-leanFiBudget-${point.effectiveDate}`;
@@ -632,12 +641,13 @@ export class YnabComponent implements OnInit {
               categoryName: category.name,
               categoryId: category.name,
               type: 'leanFiBudget',
-              baselineValue:
-                category.leanFiBudget || category.computedLeanFiBudget || 0,
+              baselineValue: lastLeanFiExpense,
               scheduledValue: point.value,
               effectiveDate: point.effectiveDate,
               enabled: !this.disabledChangeIds.has(id),
             });
+
+            lastLeanFiExpense = point.value;
           }
         }
       }
@@ -647,6 +657,8 @@ export class YnabComponent implements OnInit {
     const accounts = this.budgetForm.value.accounts || [];
     for (const account of accounts) {
       const mcSchedule = account.monthlyContributionSchedule;
+      let lastContribution = account.monthlyContribution || 0;
+      
       if (mcSchedule?.schedule?.length > 0) {
         for (const point of mcSchedule.schedule) {
           const id = `${account.name}-monthlyContribution-${point.effectiveDate}`;
@@ -660,6 +672,8 @@ export class YnabComponent implements OnInit {
             effectiveDate: point.effectiveDate,
             enabled: !this.disabledChangeIds.has(id),
           });
+
+          lastContribution = point.value;
         }
       }
     }

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -58,17 +58,11 @@ export class CalculateInput {
   }
 
   get fiNumber() {
-    const baseFi = this.safeWithdrawalTimes * this.annualExpenses;
-    return baseFi - this.externalContributionReduction + this.additionalLumpSumNeeded;
+    return this.getFiNumberAt(this.annualExpensesSeries?.getFinalDate());
   }
 
   get leanFiNumber() {
-    let baseLeanFi = this.fiNumber * this.leanFiPercentage;
-    if (this.leanAnnualExpenses) {
-      baseLeanFi = this.safeWithdrawalTimes * this.leanAnnualExpenses;
-      baseLeanFi = baseLeanFi - this.externalContributionReduction + this.additionalLumpSumNeeded;
-    }
-    return baseLeanFi;
+    return this.getLeanFiNumberAt(this.leanAnnualExpensesSeries?.getFinalDate());
   }
 
   /**
@@ -122,7 +116,7 @@ export class CalculateInput {
    * Falls back to the static value if no time series is available.
    */
   getAnnualExpensesAt(month: string): number {
-    if (this.annualExpensesSeries) {
+    if (month != null && this.annualExpensesSeries) {
       return this.annualExpensesSeries.getValueAt(month) * 12;
     }
     return this.annualExpenses;
@@ -133,7 +127,7 @@ export class CalculateInput {
    * Falls back to the static value if no time series is available.
    */
   getLeanAnnualExpensesAt(month: string): number {
-    if (this.leanAnnualExpensesSeries) {
+    if (month != null && this.leanAnnualExpensesSeries) {
       return this.leanAnnualExpensesSeries.getValueAt(month) * 12;
     }
     return this.leanAnnualExpenses;
@@ -144,7 +138,7 @@ export class CalculateInput {
    */
   getFiNumberAt(month: string): number {
     const annualExpenses = this.getAnnualExpensesAt(month);
-    return this.safeWithdrawalTimes * annualExpenses;
+    return (this.safeWithdrawalTimes * annualExpenses) - this.externalContributionReduction + this.additionalLumpSumNeeded;;
   }
 
   /**
@@ -153,7 +147,7 @@ export class CalculateInput {
   getLeanFiNumberAt(month: string): number {
     const leanAnnualExpenses = this.getLeanAnnualExpensesAt(month);
     if (leanAnnualExpenses > 0) {
-      return this.safeWithdrawalTimes * leanAnnualExpenses;
+      return (this.safeWithdrawalTimes * leanAnnualExpenses) - this.externalContributionReduction + this.additionalLumpSumNeeded;;
     }
     return this.getFiNumberAt(month) * this.leanFiPercentage;
   }

--- a/src/app/forecasting/models/calculate-input.model.ts
+++ b/src/app/forecasting/models/calculate-input.model.ts
@@ -1,4 +1,4 @@
-import { Birthdate } from '../input/ynab/birthdate-utility';
+import { Birthdate, birthdateToDate } from '../input/ynab/birthdate-utility';
 import { TimeSeries } from './time-series.model';
 import { round } from '../utilities/number-utility';
 
@@ -82,15 +82,10 @@ export class CalculateInput {
    * @returns The Coast FI number, or null if birthdate is not set
    */
   getCoastFiNumberAt(atDate: Date): number | null {
-    if (!this.birthdate || this.targetRetirementAge === null) {
+    const birthdate = birthdateToDate(this.birthdate)
+    if (!birthdate || this.targetRetirementAge === null) {
       return null;
     }
-
-    const birthdate = new Date(
-      this.birthdate.year,
-      this.birthdate.month - 1,
-      this.birthdate.day
-    );
 
     // Calculate current age in years
     const ageInMs = atDate.getTime() - birthdate.getTime();
@@ -109,14 +104,6 @@ export class CalculateInput {
       this.fiNumber / Math.pow(1 + this.expectedAnnualGrowthRate, yearsToTarget);
 
     return round(coastFi);
-  }
-
-  /**
-   * Get the Coast FI number based on current date.
-   * Returns null if birthdate is not set.
-   */
-  get coastFiNumber(): number | null {
-    return this.getCoastFiNumberAt(new Date());
   }
 
   /**

--- a/src/app/forecasting/models/forecast.model.ts
+++ b/src/app/forecasting/models/forecast.model.ts
@@ -1,11 +1,11 @@
 import { CalculateInput } from './calculate-input.model';
 import { round } from '../utilities/number-utility';
-import { Birthdate } from '../input/ynab/birthdate-utility';
+import { birthdateToDate } from '../input/ynab/birthdate-utility';
 
 export class Forecast {
   monthlyForecasts: MonthlyForecast[];
   month0Date: Date;
-  birthdate: Birthdate;
+  birthdate: Date;
 
   public constructor(calculateInput: CalculateInput, month0Date?: Date) {
     if (!calculateInput) {
@@ -14,7 +14,7 @@ export class Forecast {
     // Set month0Date first since computeForecast needs it for time-varying values
     this.month0Date = month0Date || new Date();
     this.month0Date.setDate(1); // make it the first of the month
-    this.birthdate = calculateInput.birthdate;
+    this.birthdate = birthdateToDate(calculateInput.birthdate);
     this.computeForecast(calculateInput);
     this.setDates();
   }

--- a/src/app/forecasting/models/time-series.model.ts
+++ b/src/app/forecasting/models/time-series.model.ts
@@ -90,6 +90,39 @@ export class TimeSeries {
   }
 
   /**
+   * Get the final date in the series or undefined if the series is empty.
+   */
+  getFinalDate(): string {
+    const dates = this.getScheduledDates();
+    return dates[dates.length - 1];
+  }
+
+  /**
+   * Subtracts the value of the points in a series
+   */
+  subtract(points: TimeSeries): TimeSeries {
+    const allDates = new Set<string>([
+      ...this.getScheduledDates(),
+      ...points.getScheduledDates(),
+    ]);
+
+    const result = new TimeSeries(this.getBaselineValue() - points.getBaselineValue());
+
+    Array.from(allDates).sort().forEach(date => {
+      const value = this.getValueAt(date) - points.getValueAt(date);
+      
+      const existingPoint = result.points.find(p => p.effectiveDate === date);
+      if (existingPoint) {
+        existingPoint.value = value; // update
+      } else {
+        result.addPoint(date, value); // add new
+      }
+    });
+
+    return result;
+  }
+
+  /**
    * Create a new TimeSeries with all values offset by a given amount.
    * Useful for applying a manual adjustment while preserving scheduled changes.
    */

--- a/src/app/forecasting/output/fi-text/fi-text.component.html
+++ b/src/app/forecasting/output/fi-text/fi-text.component.html
@@ -86,20 +86,21 @@
     <p *ngIf="coastFiNumber !== null">
       <strong>Coast FI</strong> is the amount needed today where, with zero
       future contributions, investment growth alone reaches your FI number by
-      age <strong>{{ targetRetirementAge }}</strong
-      >. Your Coast FI number is
-      <strong>{{
-        coastFiNumber | currency: calculateInput.currencyIsoCode
-      }}</strong
-      >. Once you reach Coast FI, you could theoretically stop saving and still
-      reach FI by your target retirement age.
+      age <strong>{{ targetRetirementAge }}</strong>.
+            
       <span *ngIf="coastFiDate !== 'Never'">
-        You are forecasted to reach Coast FI on <strong>{{ coastFiDate }}</strong
-        >; {{ coastFiDateDistance }} from now.
-        <span *ngIf="coastFiAge !== null"
-          >You'll be <strong>{{ coastFiAge }}</strong> old at that time.</span
-        >
+        <span *ngIf="coastFiDateDistance !== '0 Months'; else canCoast">
+          You can coast with a forecasted portfolio of at least <strong>{{ coastFiNumber | currency: calculateInput.currencyIsoCode }}</strong> by
+          <strong>{{ coastFiDate }}</strong>; {{ coastFiDateDistance }} from now.
+          At that time you'll be <strong>{{ coastFiAge }}</strong> old.
+          Once you reach Coast FI, you could theoretically stop saving.
+        </span>
       </span>
     </p>
   </div>
 </div>
+
+<ng-template #canCoast>
+  You've reached Coast FI! Your portfolio is at least <strong>{{ coastFiNumber | currency: calculateInput.currencyIsoCode }}</strong>,
+  which is theoretically sufficient to stop saving and still reach FI by your target retirement age.
+</ng-template>

--- a/src/app/forecasting/output/fi-text/fi-text.component.ts
+++ b/src/app/forecasting/output/fi-text/fi-text.component.ts
@@ -119,18 +119,14 @@ export class FiTextComponent implements OnInit, OnChanges {
 
     // Coast FI calculation - only show if birthdate is set
     this.targetRetirementAge = this.calculateInput.targetRetirementAge;
-    const coastFiNumber = this.calculateInput.coastFiNumber;
 
-    if (coastFiNumber === null) {
+    if (birthdate === null || isNaN(birthdate.getTime())) {
       // No birthdate set - hide Coast FI
       this.coastFiNumber = null;
       this.coastFiDate = null;
       this.coastFiDateDistance = null;
       this.coastFiAge = null;
     } else {
-      const roundedCoastFi = Math.max(0, round(coastFiNumber));
-      this.coastFiNumber = roundedCoastFi;
-
       // Find first month where net worth >= Coast FI at that month's date
       const foundCoastFiForecast = this.forecast.monthlyForecasts.find(
         (f) => {
@@ -140,10 +136,14 @@ export class FiTextComponent implements OnInit, OnChanges {
       );
 
       if (!foundCoastFiForecast) {
+        this.coastFiNumber = null;
         this.coastFiDate = 'Never';
         this.coastFiDateDistance = 'Forever';
         this.coastFiAge = undefined;
       } else {
+        const coastFiAtReachDate = this.calculateInput.getCoastFiNumberAt(foundCoastFiForecast.date);
+        this.coastFiNumber = Math.max(0, round(coastFiAtReachDate));
+
         this.coastFiDate = foundCoastFiForecast.toDateString();
         this.coastFiDateDistance =
           this.forecast.getDistanceFromFirstMonthText(

--- a/src/app/forecasting/output/impact/impact.component.html
+++ b/src/app/forecasting/output/impact/impact.component.html
@@ -25,8 +25,8 @@
         <tbody>
             <tr *ngFor="let c of spendingCategoriesWithImpact">
                 <td>{{ c.category.name }}</td>
-                <td *ngIf="activeMode === 'leanFi'">{{ c.category.leanFiBudget | currency:calculateInput.currencyIsoCode }}</td>
-                <td *ngIf="activeMode !== 'leanFi'">{{ c.category.fiBudget | currency:calculateInput.currencyIsoCode }}</td>
+                <td *ngIf="activeMode === 'leanFi'">{{ isCategoryScheduled(c.category) ? (c.category.leanFiBudget | currency:calculateInput.currencyIsoCode) : 'Varies' }}</td>
+                <td *ngIf="activeMode !== 'leanFi'">{{ isCategoryScheduled(c.category) ? (c.category.fiBudget | currency:calculateInput.currencyIsoCode) : 'Varies' }}</td>
                 <td *ngIf="activeMode === 'fi'">
                     <span [ngClass]="{'d-none': c.isFi === true}">
                         <fa-icon [icon]="['fas', 'plus-circle']"></fa-icon>
@@ -64,3 +64,7 @@
         </tbody>
     </table>
 </div>
+
+<ng-template #scheduled>
+  <td>Varies</td>
+</ng-template>

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, Input, OnChanges, SimpleChanges, } from '@angular/co
 import { Forecast } from '../../models/forecast.model';
 import { CalculateInput } from '../../models/calculate-input.model';
 import { birthdateToDate } from '../../input/ynab/birthdate-utility';
+import { aggregateTimeSeries, TimeSeries } from '../../models/time-series.model';
+import { ScheduledChangesState, SCHEDULED_CHANGES_STORAGE_KEY } from '../../models/scheduled-change.model';
 
 @Component({
     selector: 'app-expense-impact',
@@ -16,9 +18,12 @@ export class ImpactComponent implements OnInit, OnChanges {
 
     spendingCategoriesWithImpact;
     activeMode: 'fi' | 'leanFi' | 'coastFi' = 'fi';
+    
+    private scheduledChangesEnabled = true;
+    private disabledChangeIds: Set<string> = new Set();
 
     get hasCoastFi(): boolean {
-    return birthdateToDate(this.calculateInput?.birthdate) !== null && 
+        return birthdateToDate(this.calculateInput?.birthdate) !== null && 
            this.calculateInput?.targetRetirementAge !== null;
     }
 
@@ -57,14 +62,30 @@ export class ImpactComponent implements OnInit, OnChanges {
         const categories = [].concat(...this.calculateInput.budgetCategoryGroups.map((group) => {
             return group.categories;
         }));
-        const categoriesWithSpending = categories.filter((category) => {
-            return category.fiBudget > 0 || category.leanFiBudget > 0;
-        }).sort((a, b) => {
+        const categoriesWithSpending = categories.filter(category => 
+            category.fiBudget > 0 ||
+            category.leanFiBudget > 0 ||
+            (category.computedFiBudgetSchedule?.schedule || []).some(p => p.value > 0) ||
+            (category.computedLeanFiBudgetSchedule?.schedule || []).some(p => p.value > 0)
+        ).sort((a, b) => {
             return b.fiBudget - a.fiBudget;
         });
 
+        // Load scheduled changes state from localStorage
+        try {
+            const storedState = JSON.parse(
+                window.localStorage.getItem(SCHEDULED_CHANGES_STORAGE_KEY)
+            ) as ScheduledChangesState;
+            if (storedState) {
+                this.scheduledChangesEnabled = storedState.globalEnabled;
+                this.disabledChangeIds = new Set(storedState.disabledChangeIds || []);
+            }
+        } catch {
+            // Ignore parse errors, use defaults
+        }
+
         this.spendingCategoriesWithImpact = categoriesWithSpending.map((category) => {
-            const isFi = currentFiForecast.date < new Date();
+            const isFi = currentFiForecast.date <= new Date();
             const isLeanFi = currentLeanFiForecast && currentLeanFiForecast.date < new Date();
             const isCoastFi = currentCoastFiForecast && currentCoastFiForecast.date < new Date();
 
@@ -77,7 +98,7 @@ export class ImpactComponent implements OnInit, OnChanges {
                 if (isCoastFi) {
                     coastFiImpactDate = 'Achieved Coast FI!';
                 } else {
-                    const modifiedCoastCalcInput = this.getModifiedCalculateInputForCoastFi(category.fiBudget);
+                    const modifiedCoastCalcInput = this.getModifiedCalculateInput(category, 'fiBudget');
                     const modifiedCoastForecast = new Forecast(modifiedCoastCalcInput);
                     const modifiedCoastFiForecast = this.getCoastFiForecast(modifiedCoastForecast, modifiedCoastCalcInput);
                     if (modifiedCoastFiForecast) {
@@ -98,7 +119,7 @@ export class ImpactComponent implements OnInit, OnChanges {
                 };
             }
 
-            const modifiedCalcInput = this.getModifiedCalculateInput(category.fiBudget);
+            const modifiedCalcInput = this.getModifiedCalculateInput(category, 'fiBudget');
             const modifiedForecast = new Forecast(modifiedCalcInput);
             const modifiedFiForecast = this.getFiForecast(modifiedForecast, modifiedCalcInput.fiNumber);
 
@@ -109,8 +130,8 @@ export class ImpactComponent implements OnInit, OnChanges {
                 if (isLeanFi) {
                     leanImpactDate = 'Achieved Lean FI!';
                 } else {
-                    const modifiedLeanCalcInput = this.getModifiedCalculateInputForLeanFi(category.leanFiBudget);
-                    const modifiedLeanForecast = new Forecast(modifiedLeanCalcInput);
+                    const modifiedLeanCalcInput = this.getModifiedCalculateInput(category, 'leanFiBudget');
+                    const modifiedLeanForecast = new Forecast(modifiedLeanCalcInput, 'leanFiNumber');
                     const modifiedLeanFiForecast = this.getFiForecast(modifiedLeanForecast, modifiedLeanCalcInput.leanFiNumber);
                     if (modifiedLeanFiForecast) {
                         leanImpactDate = this.getImpactDateText(currentLeanFiForecast.date, modifiedLeanFiForecast.date);
@@ -130,37 +151,57 @@ export class ImpactComponent implements OnInit, OnChanges {
         });
     }
 
-    private getModifiedCalculateInput(fiSpendingReductionPerMonth: number): CalculateInput {
+    /**
+     * Get a modified CalculateInput with a single category reduced in spending
+     */
+    private getModifiedCalculateInput(category: any, scheduleType: 'fiBudget' | 'leanFiBudget' = 'fiBudget'): CalculateInput {
         const calcInput = new CalculateInput();
-        calcInput.annualExpenses = this.calculateInput.annualExpenses - fiSpendingReductionPerMonth * 12;
-        calcInput.annualSafeWithdrawalRate = this.calculateInput.annualSafeWithdrawalRate;
-        calcInput.expectedAnnualGrowthRate = this.calculateInput.expectedAnnualGrowthRate;
-        calcInput.netWorth = this.calculateInput.netWorth;
-        calcInput.monthlyContribution = this.calculateInput.monthlyContribution + fiSpendingReductionPerMonth;
-        return calcInput;
-    }
 
-    private getModifiedCalculateInputForLeanFi(leanFiSpendingReductionPerMonth: number): CalculateInput {
-        const calcInput = new CalculateInput();
-        calcInput.annualExpenses = this.calculateInput.annualExpenses;
-        calcInput.leanAnnualExpenses = this.calculateInput.leanAnnualExpenses - leanFiSpendingReductionPerMonth * 12;
-        calcInput.annualSafeWithdrawalRate = this.calculateInput.annualSafeWithdrawalRate;
-        calcInput.expectedAnnualGrowthRate = this.calculateInput.expectedAnnualGrowthRate;
-        calcInput.netWorth = this.calculateInput.netWorth;
-        calcInput.monthlyContribution = this.calculateInput.monthlyContribution + leanFiSpendingReductionPerMonth;
-        return calcInput;
-    }
+        // Determine baseline and series for this category
+        const series = this.getCategoryTimeSeries(category, scheduleType === 'fiBudget' ? 'computedFiBudgetSchedule' : 'computedLeanFiBudgetSchedule', category[scheduleType], scheduleType);
 
-    private getModifiedCalculateInputForCoastFi(fiSpendingReductionPerMonth: number): CalculateInput {
-        const calcInput = new CalculateInput();
-        calcInput.annualExpenses = this.calculateInput.annualExpenses - fiSpendingReductionPerMonth * 12;
+        // Subtract the expenses (series and annual total)
+        if (scheduleType == 'fiBudget') {
+            calcInput.annualExpensesSeries = this.calculateInput.annualExpensesSeries.subtract(series);
+            calcInput.annualExpenses = calcInput.annualExpensesSeries.getBaselineValue() * 12;
+        } else {
+            calcInput.leanAnnualExpensesSeries = this.calculateInput.leanAnnualExpensesSeries.subtract(series);
+            calcInput.leanAnnualExpenses = calcInput.leanAnnualExpensesSeries.getBaselineValue() * 12;
+            // console.log(calcInput.leanAnnualExpensesSeries);
+            // console.log(calcInput.leanAnnualExpenses);
+        }
+        
+        // Apply savings to monthly contribution
+        calcInput.monthlyContributionSeries = aggregateTimeSeries([this.calculateInput.monthlyContributionSeries, series]);
+        calcInput.monthlyContribution = calcInput.monthlyContributionSeries.getBaselineValue() * 12;
+
+        // Copy over other unchanged properties
         calcInput.annualSafeWithdrawalRate = this.calculateInput.annualSafeWithdrawalRate;
         calcInput.expectedAnnualGrowthRate = this.calculateInput.expectedAnnualGrowthRate;
         calcInput.netWorth = this.calculateInput.netWorth;
-        calcInput.monthlyContribution = this.calculateInput.monthlyContribution + fiSpendingReductionPerMonth;
         calcInput.birthdate = this.calculateInput.birthdate;
         calcInput.targetRetirementAge = this.calculateInput.targetRetirementAge;
+
         return calcInput;
+    }
+
+    /**
+     * Build a TimeSeries for a specific category from its schedule property
+     */
+    private getCategoryTimeSeries(category: any, scheduleProperty: string, baselineValue: number, scheduleType: string): TimeSeries {
+        const series = new TimeSeries(baselineValue);
+        const schedule = category[scheduleProperty];
+
+        if (schedule?.schedule?.length > 0) {
+            for (const point of schedule.schedule) {
+                const changeId = `${category.name}-${scheduleType}-${point.effectiveDate}`;
+                if (this.scheduledChangesEnabled && !this.disabledChangeIds.has(changeId)) {
+                    series.addPoint(point.effectiveDate, point.value);
+                }
+            }
+        }
+
+        return series;
     }
 
     private getCoastFiForecast(forecast: Forecast, calcInput: CalculateInput) {
@@ -199,5 +240,21 @@ export class ImpactComponent implements OnInit, OnChanges {
             return `1 ${unit} `;
         }
         return `${timeDifference} ${unit}s `;
+    }
+
+    isCategoryScheduled(category: any): boolean {
+        // Check if the series exists and has points
+        let schedule = this.activeMode == 'leanFi' ? 'computedLeanFiBudgetSchedule' : 'computedFiBudgetSchedule';
+        let scheduleType = this.activeMode == 'leanFi' ? 'leanFiBudget' : 'fiBudget';
+        const series = category[schedule]?.schedule || [];
+
+        // Filter out points that are disabled in scheduled changes
+        const activePoints = series.filter(point => {
+            const changeId = `${category.name}-${scheduleType}-${point.effectiveDate}`;
+            return this.scheduledChangesEnabled && !this.disabledChangeIds.has(changeId);
+        });
+
+        // If no active points, then budget is fixed
+        return activePoints.length === 0;
     }
 }

--- a/src/app/forecasting/output/impact/impact.component.ts
+++ b/src/app/forecasting/output/impact/impact.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, OnChanges, SimpleChanges, } from '@angular/core';
 import { Forecast } from '../../models/forecast.model';
 import { CalculateInput } from '../../models/calculate-input.model';
+import { birthdateToDate } from '../../input/ynab/birthdate-utility';
 
 @Component({
     selector: 'app-expense-impact',
@@ -17,7 +18,8 @@ export class ImpactComponent implements OnInit, OnChanges {
     activeMode: 'fi' | 'leanFi' | 'coastFi' = 'fi';
 
     get hasCoastFi(): boolean {
-        return this.calculateInput?.coastFiNumber !== null;
+    return birthdateToDate(this.calculateInput?.birthdate) !== null && 
+           this.calculateInput?.targetRetirementAge !== null;
     }
 
     setMode(mode: 'fi' | 'leanFi' | 'coastFi') {

--- a/src/app/forecasting/output/milestones/milestones.component.ts
+++ b/src/app/forecasting/output/milestones/milestones.component.ts
@@ -32,7 +32,17 @@ export class MilestonesComponent implements OnInit, OnChanges {
     const eclipseForecast = this.forecast.monthlyForecasts.find(m => {
       return m.totalContributions <= m.totalReturns;
     });
-    const coastFiNumber = this.calculateInput.coastFiNumber;
+
+    // forecast networth when coastFiNumber reached
+    let coastFiNumber = null;
+    const foundCoastFiForecast = this.forecast.monthlyForecasts.find(f => {
+      const coastFiAtMonth = this.calculateInput.getCoastFiNumberAt(f.date);
+      return coastFiAtMonth !== null && f.netWorth >= coastFiAtMonth;
+    });
+    
+    if (foundCoastFiForecast) {
+      coastFiNumber = foundCoastFiForecast.netWorth;
+    }
 
     if (!eclipseForecast) {
       this.milestones = new Milestones(

--- a/src/app/forecasting/output/milestones/text/text.component.html
+++ b/src/app/forecasting/output/milestones/text/text.component.html
@@ -21,7 +21,7 @@
         <td>{{ m.milestone.value | currency:currencyIsoCode:'symbol':'1.0'}}</td>
         <td>{{ m.forecastDate }}</td>
         <td>{{ m.distance }}</td>
-        <td *ngIf="forecast.birthdate">{{ m.age }}</td>
+        <td *ngIf="forecast.birthdate != null">{{ m.age }}</td>
         <td>{{ m.forecast?.totalContributions | currency:currencyIsoCode:'symbol':'1.0-0'}}</td>
         <td>{{ m.forecast?.totalReturns | currency:currencyIsoCode:'symbol':'1.0-0'}}</td>
       </tr>

--- a/src/app/forecasting/output/milestones/text/text.component.ts
+++ b/src/app/forecasting/output/milestones/text/text.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit, Input, OnChanges, SimpleChanges, } from '@angular/co
 import { CalculateInput } from '../../../models/calculate-input.model';
 import { Forecast, MonthlyForecast } from '../../../models/forecast.model';
 import { Milestones } from '../milestone.model';
-import { birthdateToDate } from '../../../input/ynab/birthdate-utility';
 
 @Component({
     selector: 'app-milestones-text',
@@ -65,7 +64,7 @@ export class TextComponent implements OnInit, OnChanges {
       const forecast = forecastSearch[foundIndex];
       const forecastDate = this.getDateString(forecast.date);
       const distance = this.getDistanceText(forecast.date);
-      const age = this.forecast.getDistanceFromDateText(forecast.date, birthdateToDate(this.forecast.birthdate));
+      const age = this.forecast.getDistanceFromDateText(forecast.date, this.forecast.birthdate);
       const completed = distance === this.completeText;
       return {
         milestone,


### PR DESCRIPTION
# Fixes
- [x] An invalid birthday (ex: 1970-01-40), would cause NaN errors across the page
- [x] The Coast FI text showed the Coast FI number for today, instead of the forecasted amount
- [x] The Coast FI text became anachronistic after reaching Coast FI
- [x] The Coast FI Net Worth shown in the milestones chart was actually the Coast FI number. Consequently `contributions + returns ≠ net worth`. Now the forecasted Net Worth is shown instead of the forecasted Coast FI number.
- [x] #179 
- [x] #180  

## Approach
Update the birthdate utility and cascade the fix onward.
Remove the coastFiNumber() convenience getter, it was only producing bugs. Cascade fixes onward.
Convert impact and calculate-input to respect scheduled changes.
Update the baseline value of scheduled changes as they are collected.

## Sample output from the changes

### Coast FI text
**Coast FI** is the amount needed today where, with zero future contributions, investment growth alone reaches your FI number by age **65**. You can coast with a forecasted portfolio of at least **$1,243,713.00** by **August 2039**; 13 years 6 months from now. At that time you'll be **69 years** old. Once you reach Coast FI, you could theoretically stop saving.

### Coast FI text once it has been reached
**Coast FI** is the amount needed today where, with zero future contributions, investment growth alone reaches your FI number by age **65**. You've reached Coast FI! Your portfolio is at least **$85,464.03**, which is theoretically sufficient to stop saving and still reach FI by your target retirement age.